### PR TITLE
skills/cel-programs: add adversarial generation pipeline with taxonomy and review

### DIFF
--- a/skills/cel-programs/SKILL.md
+++ b/skills/cel-programs/SKILL.md
@@ -233,7 +233,7 @@ Error message format: `"METHOD path: body-or-status"`. Code examples: `reference
 
 ### Placeholder events
 
-When advancing the cursor with no real events, emit a placeholder (`[{"retry": true}]`) and configure `drop_event.when.equals.retry: true` so it is discarded before indexing. Full pattern and alternatives: `references/cel-idioms.md`.
+When advancing the cursor with no real events, emit a placeholder (`[{"retry": true}]`) and add a `- drop_event.when.equals.retry: true` entry in the `processors:` section so it is discarded before indexing. Full pattern and alternatives: `references/cel-idioms.md`.
 
 ## Rate limiting and retry
 
@@ -314,7 +314,12 @@ Refer to the `anonymize-logs` skill for the full anonymization policy and placeh
 | `references/cel-rate-limiting.md` | Rate limiting policy — config-only approach, when to add `resource.rate_limit.*` and `resource.retry.*` settings |
 | `references/cel-idioms.md` | Quick-reference for common idioms, HTTP request patterns, structure conventions |
 | `references/cel-polymorphic-patterns.md` | Choosing between pure-CEL, mito lib, and config approaches for auth, headers, rate limiting — version-tagged |
+| `references/cel-expression.md` | Expression-specific reference: interface contract, translation framing (Python→CEL), incremental build phases, core structure, event output, error handling, pagination, state management, syntax rules, quality checklist |
+| `references/cel-taxonomy.md` | Taxonomy classification: pagination and state management classes, least-complexity principle, mapping to skill vocabulary, how to classify from test-api.py |
+| `references/cel-complexity-baselines.md` | Per-pattern-class complexity baselines from a ceplx survey of 316 programs, skip threshold, reviewer challenge examples, diagnostic interpretation |
+| `references/expression-builder-subagent-guidance.md` | Subagent operating manual for the **cel-expression-builder**: translates test-api.py into a validated `.cel` file + taxonomy classification. Does not touch templates, manifests, or mocks. |
+| `references/reviewer-subagent-guidance.md` | Subagent operating manual for the **cel-expression-reviewer**: checks generated CEL against complexity baselines and source fidelity, produces specific challenges or accepts |
 | `references/cel-function-reference.md` | Looking up available CEL functions per extension and their first mito version |
-| `references/builder-subagent-guidance.md` | **Always-embedded** subagent operating manual: scope boundaries, skill-load sequence, the 9-step mock-first / mito-incremental workflow with mock completeness gate, reporting contract |
+| `references/builder-subagent-guidance.md` | **Always-embedded** subagent operating manual for the **cel-program-builder** orchestrator: scope boundaries, skill-load sequence, the 9-step mock-first / mito-incremental workflow with mock completeness gate, delegation to cel-expression-builder, reporting contract |
 
 See also: [CEL input docs](https://www.elastic.co/docs/reference/beats/filebeat/filebeat-input-cel) · [Mito lib docs](https://pkg.go.dev/github.com/elastic/mito/lib) · [Mito repo](https://github.com/elastic/mito) · [CEL language spec](https://cel.dev/)

--- a/skills/cel-programs/references/builder-subagent-guidance.md
+++ b/skills/cel-programs/references/builder-subagent-guidance.md
@@ -3,6 +3,13 @@
 Operating manual for a subagent building or modifying CEL programs on behalf
 of the `create-integration` or `maintain-integration` orchestrator.
 
+This subagent is an **orchestrator** for CEL integration development. Its
+primary responsibilities are mock design, mock validation, template wrapping,
+manifest configuration, and system test setup. For the CEL expression itself,
+it delegates to the **cel-expression-builder** subagent (see
+`references/expression-builder-subagent-guidance.md`), which translates
+test-api.py into a validated `.cel` file.
+
 The orchestrator embeds this entire file verbatim in your task prompt, so you
 do not need to load any skill or reference file beyond what is listed in the
 "First steps" section below.
@@ -125,22 +132,19 @@ program, and the system test infrastructure consistent from the start.
 examples, API documentation, and a clear picture of the final template, you
 MUST follow this order:
 
-1. Investigate the API
-2. Create the system test mock config (with the full two-round flow described
-   in step 3c)
+1. Investigate the API via test-api.py (the ground truth)
+2. Derive the system test mock from test-api.py's request/response flow
+   (with the full two-round flow described in step 3c)
 3. Start the mock locally
-4. If a research `test-api.py` script exists, run it against the mock to
-   verify the mock is correct
+4. Validate the mock with test-api.py (hard gate — do not proceed until
+   it passes)
 5. Verify mock completeness gate (2+ pages, terminal page, second-round
    cursor resume, optional regression guard)
-6. Write a standalone `.cel` file and `state.json` (NOT a template)
-7. Run mito against the mock **incrementally** through the phases in
-   `references/cel-incremental-build.md` (skeleton → error handling →
-   events → pagination → cursor); iterate until each phase passes before
-   adding the next
-8. ONLY THEN write `cel.yml.hbs` by wrapping the validated program in
+6. Build the CEL expression (preferred: delegate to cel-expression-builder
+   with test-api.py as the translation source)
+7. ONLY THEN write `cel.yml.hbs` by wrapping the validated program in
    Handlebars
-9. Run `celfmt -s -agent`, configure manifest vars, define field mappings,
+8. Run `celfmt -s -agent`, configure manifest vars, define field mappings,
    validate
 
 Writing the template first and trying to extract a `.cel` file from
@@ -153,33 +157,42 @@ test against the live API for highest-confidence validation, but mock-first
 development is always the primary path — it is faster, reproducible, and
 does not depend on API availability or rate limits.
 
-### Step 1 — investigate the API
+### Step 1 — investigate the API via test-api.py
 
-From the orchestrator's prompt, research brief, or API documentation,
-identify:
+**Start with the research `test-api.py` script.** This is always present
+for CEL integrations and is the ground truth — it has been tested against
+the real API. Read its collection function (`run_collection()` or
+equivalent) to identify:
 
 - Base URL and endpoint paths
 - Authentication method (header auth, query parameter auth, signed query
   params, OAuth2 client credentials, OAuth2 token refresh)
-- Pagination pattern — pick from the table in the `cel-programs` skill /
-  `references/cel-pagination-patterns.md` (offset, timestamp cursor, link
-  header, next-URL, next-token + timestamp bookmark, GraphQL cursor,
-  multi-step state machine)
+- Pagination pattern — which loop structure and termination condition does
+  the Python script use? Map it to the patterns in the `cel-programs`
+  skill / `references/cel-pagination-patterns.md`
 - Response JSON structure (where the event array lives, total count fields,
-  next-page indicators)
+  next-page indicators) — visible in the script's response navigation
 - Time-range filtering parameters
 - Batch size constraints
+- Error handling branches (status codes, missing fields, malformed responses)
 
-If the API documentation is incomplete and credentials are available, use
-`curl` or `python` to make exploratory requests against the real API to
-confirm the exact response structure, pagination behaviour, and error
-responses before designing the mock.
+The research brief provides supplementary context (field meanings, edge
+cases not exercised by the script). If the API documentation is incomplete
+and credentials are available, use `curl` or `python` to make exploratory
+requests against the real API, but the Python script remains the primary
+specification.
 
-### Step 2 — set up the system test mock API FIRST
+### Step 2 — derive the system test mock from test-api.py
 
 Before writing any CEL code, build the mock HTTP API the system test will
-use. Use the `elastic/stream` http-server — do NOT write a custom Python
-mock.
+use. The mock is **derived from** test-api.py's request/response flow, not
+independently designed from the research brief. The Python script defines
+which endpoints are called, what request shapes are sent, and what
+response structures are expected — the mock replays this interaction with
+anonymised data. If a `trace.json` exists from a real API run, use it as
+a reference for response structure and field presence.
+
+Use the `elastic/stream` http-server — do NOT write a custom Python mock.
 
 1. Define the mock service in `_dev/deploy/docker/docker-compose.yml` using
    `docker.elastic.co/observability/stream:v0.20.0`.
@@ -232,24 +245,29 @@ Either approach gives mito the exact same mock the system test will use —
 no divergence between what mito tests and what `elastic-package test system`
 tests.
 
-### Step 3b — validate the mock with the research `test-api.py` (if available)
+### Step 3b — validate the mock with test-api.py (hard gate)
 
-If the orchestrator provided a research results folder containing a
-`test-api.py` Python script that documents the expected request/response
-flow, **run it against the running mock** before writing CEL:
+**This is a hard gate, not optional.** The research `test-api.py` script
+is always present for CEL integrations. Run it against the running mock
+before writing any CEL:
 
 ```bash
-python3 test-api.py --base-url http://localhost:8090
+python3 test-api.py --base-url http://localhost:8090 --mock
 ```
 
-If the script fails against the mock, assume the mock is wrong unless there
-is an obvious flaw in the script (wrong endpoint path, missing optional
-header). Fix the mock rules to match what the script expects (missing query
-params, wrong response shape, missing auth endpoint, wrong status codes).
+If the script fails against the mock, assume the mock is wrong unless
+there is an obvious flaw in the script (wrong endpoint path, missing
+optional header). Fix the mock rules to match what the script expects
+(missing query params, wrong response shape, missing auth endpoint, wrong
+status codes).
 
-If the script passes (or no script exists), proceed to step 3c. This step
-catches mock design errors early — before you spend time building a CEL
-program against a broken mock.
+Do NOT proceed to step 3c until test-api.py passes against the mock. This
+gate ensures the mock faithfully models the API interaction that the CEL
+program will be translated from.
+
+If a `trace.json` exists from a real API run, compare the mock's responses
+against it as an additional fidelity check — field presence, response
+shape, and pagination state transitions should match.
 
 ### Step 3c — verify mock completeness gate (hard gate)
 
@@ -285,10 +303,62 @@ Sum events from all pages across both rounds — that sum is the
 
 Do NOT proceed to step 4 until the mock implements all of the above.
 
-### Step 4 — prototype with mito against the mock (incremental build, mandatory)
+### Step 4 — build the CEL expression
 
 **Every CEL program must be developed and validated through mito.** This is
 not optional. The mock from step 3 is already running.
+
+#### Preferred path — delegate to cel-expression-builder
+
+When the orchestrator provided a `test-api.py` script (which is always the
+case for new CEL integrations), launch a **cel-expression-builder** subagent
+with:
+
+- The `test-api.py` file content
+- A `state.json` with literal test values (url pointing at the running mock,
+  credentials, batch_size, initial_interval)
+- The mock URL
+- The research brief (if available)
+
+Embed the full content of
+`references/expression-builder-subagent-guidance.md` in the subagent's task
+prompt. The expression builder returns a validated `.cel` file and a taxonomy
+classification.
+
+#### Step 4b — structured review (when complexity warrants it)
+
+After receiving the `.cel` file and classification from the expression
+builder, run `ceplx -diag -json program.cel` to get complexity metrics.
+
+**Skip the review** if cognitive complexity is below the class p50 (from
+`references/cel-complexity-baselines.md`) **and** below 40.
+
+Otherwise, launch a **cel-expression-reviewer** subagent with:
+
+- The generated `.cel` file
+- The taxonomy classification
+- The `ceplx -diag -json` output
+- The `test-api.py` file content
+- The research brief
+
+Embed the full content of `references/reviewer-subagent-guidance.md` in
+the subagent's task prompt.
+
+If the reviewer returns **revise**, pass the challenges back to the
+expression builder (resume the same subagent) and ask it to address
+each challenge — either justify the current approach or produce a
+revised `.cel` file.
+
+If a revision is produced, re-run `ceplx` and compare. Select the
+version with lower complexity unless the revision drops fidelity.
+
+Proceed to step 5 with the final `.cel` file.
+
+#### Direct path — build expression yourself
+
+If the orchestrator did not provide `test-api.py`, or if you are fixing an
+existing CEL program rather than building one from scratch, build the
+expression directly following the incremental approach below.
 
 **Build incrementally — never write the full program at once.** Even if you
 "know" what the final program looks like, follow the phased ladder in
@@ -322,7 +392,7 @@ You can also validate and simplify the standalone `.cel` syntax with
 `celfmt` during this step — it works on plain `.cel` files too:
 
 ```bash
-celfmt -s program.cel -o /dev/null
+celfmt -s -i program.cel -o /dev/null
 ```
 
 If `celfmt` hangs on a standalone `.cel` file (a known issue in some

--- a/skills/cel-programs/references/cel-complexity-baselines.md
+++ b/skills/cel-programs/references/cel-complexity-baselines.md
@@ -1,0 +1,105 @@
+# CEL complexity baselines
+
+Per-pattern-class complexity baselines from a survey of 316 CEL programs
+in elastic/integrations, measured with `ceplx`. The reviewer uses these
+to challenge generated programs that exceed expected complexity for their
+pattern class.
+
+**Source:** `ceplx` survey of `elastic/integrations` (May 2026), joined
+with `celir` taxonomy classifications. Raw data in
+`~/thinking/cel_complexity/ceplx-joined.csv`.
+
+## How to use
+
+1. Classify the program using `references/cel-taxonomy.md`.
+2. Look up the class in the tables below.
+3. If the class has n >= 10, use the class-specific baselines.
+4. If n < 10, use the global percentiles as a fallback.
+5. A program above p90 for its class needs justification — the API's
+   requirements may warrant it, but the burden is on the generator to
+   explain why.
+
+## Skip threshold
+
+Skip the review when **both** conditions hold:
+- The program's cognitive complexity is below the class p50
+- Total cognitive complexity is below 40
+
+These programs are simple enough that review overhead is not justified.
+
+## By pagination pattern
+
+Only classes with n >= 10 are reliable baselines. Classes with smaller
+samples are included for reference but should be used cautiously.
+
+| Pattern | n | cyc_med | cyc_p90 | cog_med | cog_p75 | cog_p90 | cog_max |
+|---------|---|---------|---------|---------|---------|---------|---------|
+| `offset` | 19 | 16 | 39 | 47 | 73 | 169 | 169 |
+| `cursor_token` | 16 | 11 | 15 | 27 | 42 | 49 | 54 |
+| `worklist_expansion` | 15 | 26 | 49 | 88 | 172 | 307 | 391 |
+| `none` | 15 | 7 | 12 | 18 | 26 | 41 | 43 |
+| `multi_entity_orchestration` | 13 | 35 | 52 | 143 | 156 | 234 | 325 |
+| `next_url_in_body` | 10 | 16 | 34 | 52 | 78 | 168 | 168 |
+| `page_number` | 8 | 18 | 31 | 73 | 82 | 82 | 82 |
+| `graphql_relay` | 6 | 9 | 35 | 31 | 51 | 64 | 64 |
+| `export_blob` | 5 | 34 | 35 | 132 | 134 | 134 | 134 |
+| `link_header` | 4 | 18 | 24 | 49 | 94 | 94 | 94 |
+| `async_job_polling` | 4 | 40 | 58 | 131 | 252 | 252 | 252 |
+
+Composite patterns (e.g., `offset + time_window`) have very small
+samples (n <= 4) and are not listed as reliable baselines.
+
+## By state management pattern
+
+| Pattern | n | cyc_med | cyc_p90 | cog_med | cog_p75 | cog_p90 | cog_max |
+|---------|---|---------|---------|---------|---------|---------|---------|
+| `state_machine` | 21 | 35 | 51 | 107 | 212 | 234 | 268 |
+| `stateless` | 18 | 7 | 13 | 18 | 29 | 43 | 47 |
+| `timestamp_cursor` | 11 | 14 | 20 | 46 | 69 | 73 | 110 |
+| `multi_field_cursor` | 7 | 17 | 64 | 41 | 104 | 296 | 296 |
+| `time_window` | 6 | 25 | 38 | 110 | 170 | 210 | 210 |
+| `job_cursor` | 5 | 40 | 58 | 114 | 131 | 252 | 252 |
+
+## Global percentiles (fallback)
+
+When the pattern class has n < 10, use these global baselines derived
+from all 316 programs:
+
+| Metric | p25 | p50 | p75 | p90 | max |
+|--------|-----|-----|-----|-----|-----|
+| Cyclomatic | 8 | 16 | 30 | 43 | 73 |
+| Cognitive | 19 | 47 | 107 | 172 | 391 |
+
+## Interpreting ceplx diagnostic output
+
+Run `ceplx -diag -json program.cel` to get per-node complexity
+contributions. The reviewer should focus on:
+
+- **High-cost comprehensions**: `.map()` and `.filter()` inside nested
+  `.as()` chains multiply cognitive cost
+- **Deep ternary nesting**: each level of `? ... : ...` inside `.as()`
+  adds both cyclomatic and cognitive complexity
+- **Logical chains**: `&&` / `||` chains inside conditions add
+  cyclomatic complexity
+- **`.as()` depth**: each level amplifies the cognitive cost of
+  everything inside it
+
+The diagnostic output identifies which nodes contribute most, guiding
+specific refactoring suggestions (extract pre-bindings, inline
+single-use bindings, split branches into separate evaluations).
+
+## Reviewer challenge examples
+
+Given a `cursor_token` program with cognitive complexity 85:
+
+> "This is a cursor_token program. The p90 for cursor_token is 49
+> (n=16). Your program's cognitive complexity is 85, which is well
+> above the baseline. The diagnostic shows 40 points from the nested
+> ternary at line 25 inside a 3-level `.as()` chain. Can this be
+> flattened with pre-bindings?"
+
+Given a `graphql_relay` program with cognitive complexity 35:
+
+> "This is a graphql_relay program. The p50 is 31, p90 is 64 (n=6,
+> treat as approximate). Your program is within expected range. No
+> complexity challenge."

--- a/skills/cel-programs/references/cel-expression.md
+++ b/skills/cel-programs/references/cel-expression.md
@@ -1,0 +1,381 @@
+# CEL expression reference
+
+This reference covers the CEL expression itself — the program that runs
+inside `program: |` in a cel.yml.hbs template. It does not cover
+Handlebars, YAML template anatomy, manifest configuration, or system
+test setup.
+
+The expression builder's job: given `state.json` (literal test values)
+and a running mock URL, produce a validated `.cel` file via incremental
+mito development.
+
+---
+
+## Interface contract
+
+**Inputs:**
+- `test-api.py` — the Python implementation of the API interaction
+  (the specification; the ground truth)
+- `state.json` — keys matching the future `state:` block, with literal
+  test values (url pointing at the mock, credentials, batch_size, etc.)
+- Mock URL — a running `elastic/stream` mock derived from test-api.py
+- Research brief — supplementary context (field meanings, edge cases
+  not exercised by the script)
+
+**Outputs:**
+- A validated `.cel` file that passes mito against the mock
+- A taxonomy classification (pagination pattern + state management
+  pattern at the least complex class that satisfies requirements)
+
+The expression builder never touches `cel.yml.hbs`, manifests, or
+system test files. It returns the working CEL expression and the
+classification. The orchestrator wraps it.
+
+---
+
+## Translation framing
+
+The task is **translation from Python to CEL**, not generation from
+prose. The test-api.py collection function (`run_collection()` or
+`collect()`) is the specification. Every construct has a direct CEL
+equivalent:
+
+| Python construct | CEL equivalent |
+|-----------------|---------------|
+| `requests.get(url, headers=...)` | `request("GET", url).with({"Header": ...}).do_request()` |
+| `if resp.status_code != 200:` | `resp.StatusCode == 200 ? ... : {error event}` |
+| `resp.json()` | `resp.Body.decode_json()` |
+| `data["items"]` | `body.items` or `body.?items.orValue([])` |
+| `while has_next_page:` | `"want_more": has_next_cursor` |
+| `cursor = resp["next"]` | `"cursor": {"next": body.next}` |
+| `for item in items:` | `body.items.map(e, {"message": e.encode_json()})` |
+| `if "errors" in resp:` | `has(body.errors) ? ... : ...` |
+
+The builder translates the collection function, not the CLI scaffolding
+(argument parsing, logging, archiving).
+
+---
+
+## Incremental build phases
+
+Every expression must be built in phases, validating with mito after
+each. Do NOT write the full program before running mito.
+
+| Phase | What to add | Corresponds to in Python |
+|-------|------------|------------------------|
+| 0 — skeleton | `state.with(request(...).do_request().as(resp, {...}))` | `do_request()` call structure |
+| 1 — error handling | `resp.StatusCode == 200 ?` branch with error event | Status code checks, exception handling |
+| 2 — event mapping | `body.items.map(e, {"message": e.encode_json()})` | Response navigation + event extraction |
+| 3 — pagination | `want_more` + cursor/offset/token tracking | `while` loop + cursor propagation |
+| 4 — cursor guard | `state.?cursor.field.orValue(...)` for first-vs-subsequent | Initial-vs-subsequent run handling |
+
+Run mito after each phase (always use `-fb` for filebeat-compatible
+validation):
+```bash
+mito -fb -data state.json -log_requests program.cel
+```
+
+For pagination testing:
+```bash
+mito -fb -data state.json -log_requests -max_executions 5 program.cel
+```
+
+For cursor persistence testing:
+```bash
+mito -fb -data state_cursor.json -log_requests -max_executions 3 program.cel
+```
+
+---
+
+## Core structure
+
+Every HTTP-based expression has this shape:
+
+```
+[pre-bindings: cursor defaults, window math, URL construction]
+state.with(
+  request(...).do_request().as(resp,        ← level 1
+    resp.StatusCode == 200 ?
+      resp.Body.decode_json().as(body, {    ← level 2
+        ...result map...
+      })
+    : { ...error... }
+  )
+)
+```
+
+**Hard cap: `.as()` depth must never exceed 5 levels** on any
+execution path. HTTP programs target 2 levels inside `state.with()`.
+
+### Pre-bindings
+
+Extract these *before* `state.with()`:
+- Cursor defaults: `state.?cursor.last_ts.orValue(...)`
+- Window bounds: `now - duration(state.initial_interval)`
+- URL construction for complex paths
+- Page tokens from previous state
+
+Do NOT bind single-use values with `.as()` — inline them.
+
+### Result map
+
+The map inside `body.as(body, {...})` contains:
+- `"events"`: the event array
+- `"cursor"`: state to persist across restarts
+- `"want_more"`: pagination continuation signal
+- `"url"`: preserved from state (required)
+
+### Flat decode pattern (structural constraint)
+
+After `try(resp.Body.decode_json()).as(body, ...)` or
+`resp.Body.decode_json().as(body, ...)`, the success path must follow
+this shape:
+
+```cel
+body.as(body,
+  error_check_1 ? error_result_1 :
+  error_check_2 ? error_result_2 :
+    {
+      "items": body.?data.orValue([]),
+      "next":  body.?pagination.next.orValue(""),
+    }.as(page, {
+      "events": page.items.map(e, {"message": e.encode_json()}),
+      "want_more": size(page.items) > 0 && page.next != "",
+      "cursor": { "next": page.next },
+      "url": state.url,
+    })
+)
+```
+
+The key technique: **extract response navigation into a flat
+intermediate map**, then build the result from that map. Do NOT chain
+nested `.as()` calls to extract individual fields. Each `.as()` level
+multiplies cognitive complexity of everything inside it.
+
+**Wrong — nested extraction (high complexity):**
+```cel
+body.?events.optMap(events, type(events)==type([]) ? dyn(events) : dyn([]))
+  .orValue([]).as(events_list,
+    body.?pagination.optMap(pg, pg.?next.optMap(n, n).orValue(""))
+      .orValue("").as(next_str,
+        { ... result using events_list and next_str ... }
+      )
+  )
+```
+
+**Right — intermediate map (low complexity):**
+```cel
+{
+  "items": body.?events.orValue([]),
+  "next":  body.?pagination.next.orValue(""),
+}.as(page, {
+  "events": page.items.map(e, {"message": e.encode_json()}),
+  "want_more": size(page.items) > 0 && page.next != "",
+  "cursor": { "next": page.next },
+  "url": state.url,
+})
+```
+
+Both extract the same two values from the response body. The
+intermediate map does it in one `.as()` level; the nested version uses
+two (or more). The complexity difference compounds with every additional
+field extracted.
+
+### Worked example: Airtable (cursor_token + time_window)
+
+Python (`run_collection`):
+```python
+events = body.get("events", [])
+next_token = body.get("pagination", {}).get("next", "")
+# stop if no events or no next token
+if not events or not next_token:
+    break
+```
+
+CEL (flat):
+```cel
+state.?cursor.next.orValue("").as(page_token,
+  state.with(
+    request("GET", url + "?" + query_params).with({...}).do_request().as(resp,
+      resp.StatusCode == 200 ?
+        try(resp.Body.decode_json()).as(parsed,
+          is_error(parsed) ? { error result } :
+          parsed.as(body,
+            (has(body.error) && body.error != null) ? { error result } :
+              {
+                "items": body.?events.orValue([]),
+                "next":  body.?pagination.next.orValue(""),
+              }.as(page, {
+                "events": page.items.map(e, {"message": e.encode_json()}),
+                "want_more": size(page.items) > 0 && page.next != "",
+                "cursor": { "next": page.next },
+                "url": state.url,
+              })
+          )
+        )
+      : { error result }
+    )
+  )
+)
+```
+
+`.as()` depth inside `state.with()`: resp (1) → parsed (2) → body (3)
+→ page (4). The page level is the intermediate map — it doesn't add
+nesting depth to the result map contents because the result map is a
+flat literal.
+
+### Worked example: Buildkite (graphql_relay + time_window)
+
+Python (`run_collection`):
+```python
+edges = parsed["data"]["organization"]["auditEvents"]["edges"]
+page_info = parsed["data"]["organization"]["auditEvents"]["pageInfo"]
+has_next = page_info.get("hasNextPage", False)
+end_cursor = page_info.get("endCursor", "")
+```
+
+CEL (flat, with relay condition pre-bound):
+```cel
+poll_from.as(poll_from,
+  pages_before.as(pages_before,
+    state.with(
+      post_request(...).do_request().as(resp,
+        resp.StatusCode == 200 ?
+          try(resp.Body.decode_json()).as(parsed,
+            is_error(parsed) ? { error } :
+            size(parsed.?errors.orValue([])) > 0 ? { graphql error } :
+            (!has(parsed.?data.organization) || ...) ? { org error } :
+              parsed.data.organization.?auditEvents.orValue({"edges":[],"pageInfo":{}}).as(audit, {
+                "has_next": audit.?pageInfo.?hasNextPage.orValue(false),
+                "end_cursor": string(audit.?pageInfo.?endCursor.orValue("")),
+                "edges": audit.?edges.orValue([]),
+              }.as(page, {
+                "events": page.edges.map(e, {"message": e.node.encode_json()}),
+                "want_more": page.has_next && page.end_cursor != "" && (pages_before+1) < int(state.max_pages),
+                "cursor": page.has_next && page.end_cursor != "" && (pages_before+1) < int(state.max_pages) ?
+                  {"poll_occurred_at_from": poll_from, "after": page.end_cursor, "pages_in_cycle": pages_before+1}
+                : {},
+                "url": state.url,
+              }))
+          )
+        : { error }
+      )
+    )
+  )
+)
+```
+
+The relay condition (`has_next && end_cursor != "" && pages < max`) is
+expressed once in `page.has_next && page.end_cursor != ""` rather than
+repeated with full optional-access chains. The intermediate map absorbs
+the navigation complexity; the result map stays flat.
+
+---
+
+## Event output
+
+Events contain ONLY `"message"`:
+```cel
+body.items.map(e, {"message": e.encode_json()})
+```
+
+Do NOT set `@timestamp` or any other field. The framework handles
+metadata. Duplicating `@timestamp` causes silent document rejection
+in ES 9.x.
+
+---
+
+## Error handling
+
+Every HTTP request needs a status check. Two error forms:
+
+**Single-object error (retry — deletes cursor):**
+```cel
+resp.StatusCode == 200 ?
+  ...success...
+: {
+    "events": {
+      "error": {"message": "GET /path: " + string(resp.StatusCode)}
+    },
+    "want_more": false,
+  }
+```
+
+**Array error (advance — preserves cursor):**
+```cel
+"events": [{"error": {"message": "..."}}],
+"cursor": state.cursor,
+"want_more": false,
+```
+
+Use single-object (retry) when data was not collected. Use array
+(advance) when the program should skip past the error.
+
+---
+
+## Pagination
+
+The `want_more` field drives pagination. Set it based on the API's
+pagination signal, NOT based on whether events were returned:
+
+```cel
+"want_more": body.?meta.next.orValue("") != "",
+"cursor": {
+  "next": body.?meta.next.orValue(""),
+  "last_ts": /* high-water mark */,
+},
+```
+
+**Cursor field separation:** Store page tokens (transient, drive
+`want_more`) and time bookmarks (persistent, drive the starting point)
+as separate cursor fields. Never use one field for both.
+
+---
+
+## State management rules
+
+1. `state.url` — from `resource.url` config; preserve in output
+2. `cursor` — only state persisted across restarts
+3. `events` — removed after each evaluation; never rely on it
+4. `want_more: true` — triggers immediate re-evaluation (only if
+   `events` is non-empty)
+5. Numbers are float64; cast with `int()` for integer operations
+6. Optional access: `state.?cursor.field.orValue(default)`
+7. After first `?` in a chain, subsequent `?` are automatic
+
+---
+
+## Syntax rules
+
+| Wrong | Correct |
+|-------|---------|
+| `(str + ":").bytes()` | `bytes(str + ":")` |
+| `str.parse_time()` | `str.parse_time("2006-01-02...", "UTC")` |
+| `(a, b, false)` | `{"a": a, "b": b, "done": false}` |
+| `body.?more.orValue(false) == true` | `body.?more.orValue(false)` |
+| Deep `.as()` nesting (>5) | Extract pre-bindings, keep <=5 |
+| Single-use `.as(x, ...x...)` | Inline the value directly |
+| Repeated sub-expression (3+ times) | Extract into a pre-binding `.as(name, ...)` |
+| Flat map with 1 field `.as(p, ...p.f...)` | Inline the field — flat decode is for 2+ fields |
+| `int(size(x))` | `size(x)` — `size` already returns `int` |
+| `x ? [] : y ? [] : z ? [] : val` | `(x \|\| y \|\| z) ? [] : val` — collapse ternaries sharing a default |
+| `x.?f.hasValue() ? optional.of(x.f) : optional.none()` | `x.?f` — optional access already returns an optional |
+| `state.?cursor.?field` | `state.?cursor.field` — only the first `?` is needed; the rest propagate |
+
+---
+
+## Quality checklist
+
+Before returning the `.cel` file, verify:
+
+- [ ] Passes mito against the mock at each phase
+- [ ] All error paths from test-api.py are represented
+- [ ] Pagination logic matches the Python loop's termination conditions
+- [ ] Response fields navigated the same way as the Python script
+- [ ] Cursor state captures the same info Python propagates between iterations
+- [ ] No invented logic (branches that don't exist in the Python source)
+- [ ] `.as()` depth <= 5 on every path
+- [ ] No rate limiting or retry logic in the expression
+- [ ] Events contain only `"message"`
+- [ ] `want_more` driven by pagination signal, not event count
+- [ ] `celfmt -s -i program.cel -o program.cel` run to simplify/format the final file

--- a/skills/cel-programs/references/cel-idioms.md
+++ b/skills/cel-programs/references/cel-idioms.md
@@ -108,13 +108,16 @@ The input only persists cursor updates when at least one event is published. Whe
 ),
 ```
 
+Then add a `drop_event` processor in `cel.yml.hbs` to discard it before indexing:
+
 ```yaml
-drop_event.when.equals.retry: true
+processors:
+- drop_event.when.equals.retry: true
 ```
 
 The `dyn()` wrapping is required because the two branches have different compile-time types (`list(map(string,string))` vs `list(map(string,bool))`). See `cel-incremental-build.md` for the full workflow: write without `dyn()` first, add it only when `celfmt -s` reports a type mismatch, then verify both paths with mito.
 
-The alternative form uses `[{"message": "retry"}]` with `drop_event.when.equals.message: retry`. The boolean form is preferred — `retry` is a dedicated control flag that no real event would have. The `{"message": "retry"}` form avoids the type mismatch (both branches are `map(string,string)`) so `dyn()` is not needed.
+The alternative form uses `[{"message": "retry"}]` with `- drop_event.when.equals.message: retry` in `processors:`. The boolean form is preferred — `retry` is a dedicated control flag that no real event would have. The `{"message": "retry"}` form avoids the type mismatch (both branches are `map(string,string)`) so `dyn()` is not needed.
 
 ## Error handling
 

--- a/skills/cel-programs/references/cel-taxonomy.md
+++ b/skills/cel-programs/references/cel-taxonomy.md
@@ -1,0 +1,114 @@
+# CEL program taxonomy
+
+Classification system for CEL program patterns. Used by the expression
+builder to select the least complex pattern class, and by the reviewer
+to select complexity baselines.
+
+## Principle
+
+**Classify at the least complex class that satisfies the API's
+requirements.** If cursor_token suffices, do not use state_machine. If
+offset works, do not use worklist_expansion. The classification
+constrains the generator and gives the reviewer its baseline.
+
+## Classification dimensions
+
+### Pagination
+
+Classes are ordered by increasing complexity. Choose the first class
+that fully describes the API's pagination mechanism.
+
+| Class | Description | Python indicators |
+|-------|-------------|-------------------|
+| `none` | Single request, no pagination | No loop; single GET/POST |
+| `cursor_token` | Opaque token in response body drives next request | `next_token = resp["meta"]["next"]`; `while next_token:` |
+| `offset` | Numeric offset incremented by page size | `offset += limit`; `while offset < total:` |
+| `page_number` | Page index incremented by 1 | `page += 1`; `while page <= max_pages:` |
+| `next_url_in_body` | Full URL in response body used as next request URL | `next_url = resp["next_link"]`; `requests.get(next_url)` |
+| `link_header` | RFC 5988 `Link` header with `rel="next"` | `resp.headers["Link"]`; parse for `rel="next"` |
+| `graphql_relay` | GraphQL `pageInfo.hasNextPage` + `after: endCursor` | `variables["after"] = pageInfo["endCursor"]`; `while hasNextPage:` |
+| `worklist_expansion` | List parent → fetch per-item detail | Outer loop lists IDs, inner loop fetches each |
+| `async_job_polling` | Submit job → poll status → fetch results | POST to start, GET to poll, GET to download |
+| `export_blob` | Request export → download file | POST export, poll until ready, GET blob |
+| `multi_entity_orchestration` | Multiple resource types, subscription management, work queues | Multiple endpoint loops with shared state |
+
+### State management
+
+| Class | Description | Python indicators |
+|-------|-------------|-------------------|
+| `stateless` | No state persisted between polls | No cursor, no bookmark |
+| `timestamp_cursor` | High-water mark timestamp advanced each poll | `bookmark = max(timestamps)`; next poll uses `since=bookmark` |
+| `time_window` | Bounded from/to window, recomputed each poll | `from = now - interval`; `to = now`; no advancing bookmark |
+| `state_machine` | Multiple phases with transitions | `if state == "subscribe": ... elif state == "fetch":` |
+| `job_cursor` | Job ID or session token persisted across polls | `job_id = resp["job_id"]`; next poll resumes job |
+
+## Mapping to skill vocabulary
+
+The `cel-programs` skill and the celir taxonomy use different category
+names. This table maps between them. The skill's vocabulary is
+authoritative for code generation.
+
+| Skill term | Taxonomy class(es) |
+|------------|-------------------|
+| Offset pagination | `offset`, `page_number` |
+| Next-URL pagination | `next_url_in_body`, `link_header` |
+| Timestamp cursor | `cursor_token` (when the token is a timestamp), `timestamp_cursor` |
+| GraphQL cursor | `graphql_relay` |
+| Multi-step state machine | `worklist_expansion`, `async_job_polling`, `export_blob`, `multi_entity_orchestration`, `state_machine` |
+
+## Composite patterns
+
+Real APIs sometimes combine strategies. When this happens, use the
+**primary pagination mechanism** for the pagination class and note the
+secondary in the classification output. Examples:
+
+- `cursor_token` + `timestamp_cursor`: token drives pagination within
+  a poll, timestamp bookmark drives the starting point across polls.
+  Pagination class: `cursor_token`. State class: `timestamp_cursor`.
+- `link_header` + `timestamp_cursor`: same split. Pagination class:
+  `link_header`. State class: `timestamp_cursor`.
+
+The two dimensions (pagination + state management) are independent.
+A program can be `graphql_relay` + `time_window` or `offset` +
+`timestamp_cursor`.
+
+## How to classify from test-api.py
+
+Read the collection function (`run_collection()` or `collect()`):
+
+1. **Pagination class**: What drives the `while` loop? What value from
+   the response determines whether to fetch another page?
+   - Opaque string token → `cursor_token`
+   - Numeric offset/skip → `offset`
+   - Page number → `page_number`
+   - Full URL → `next_url_in_body`
+   - Link header → `link_header`
+   - GraphQL pageInfo → `graphql_relay`
+   - No loop → `none`
+
+2. **State management class**: How does the script resume on the next
+   run? What does `main()` pass to the collection function?
+   - Nothing / fixed lookback → `time_window` or `stateless`
+   - Advancing timestamp bookmark → `timestamp_cursor`
+   - Job ID from previous run → `job_cursor`
+   - Phase/state variable → `state_machine`
+
+3. **Verify least complexity**: Could a simpler class work? If the API
+   returns an opaque cursor but you classified as `state_machine`,
+   reconsider — `cursor_token` may suffice.
+
+## Classification output format
+
+Return the classification as two fields alongside the `.cel` file:
+
+```
+Pagination: cursor_token
+State management: timestamp_cursor
+```
+
+If the pattern is composite, note the secondary:
+
+```
+Pagination: cursor_token (primary) + timestamp_cursor (bookmark across polls)
+State management: timestamp_cursor
+```

--- a/skills/cel-programs/references/cel-template-examples.md
+++ b/skills/cel-programs/references/cel-template-examples.md
@@ -217,7 +217,6 @@ program: |
       )
     )
   )
-drop_event.when.equals.retry: true
 
 tags:
 {{#if preserve_original_event}}
@@ -229,8 +228,9 @@ tags:
 {{#contains "forwarded" tags}}
 publisher_pipeline.disable_host: true
 {{/contains}}
-{{#if processors}}
 processors:
+- drop_event.when.equals.retry: true
+{{#if processors}}
 {{processors}}
 {{/if}}
 ```

--- a/skills/cel-programs/references/expression-builder-subagent-guidance.md
+++ b/skills/cel-programs/references/expression-builder-subagent-guidance.md
@@ -1,0 +1,198 @@
+# CEL expression builder subagent guidance
+
+Operating manual for a subagent that translates a Python API interaction
+(test-api.py) into a validated CEL expression. Returns a working `.cel`
+file and a taxonomy classification. Does not touch cel.yml.hbs,
+manifests, or system tests.
+
+The orchestrator embeds this file verbatim in your task prompt, so you
+do not need to load any skill or reference file beyond what is listed in
+the "First steps" section below.
+
+## Scope
+
+Your sole job is to translate a working Python API interaction into an
+equivalent CEL program, validate it with mito against a running mock,
+and return the validated `.cel` file alongside a taxonomy classification.
+
+**You do NOT:**
+- Write or modify `cel.yml.hbs` templates
+- Configure manifests or data stream vars
+- Set up system tests or mock APIs
+- Run `elastic-package` commands
+- Create field mappings
+
+The orchestrator handles all of that. You produce a validated CEL
+expression and nothing else.
+
+## Your inputs
+
+The orchestrator provides:
+
+1. **`test-api.py`** — the Python implementation of the API interaction.
+   This is your specification. The collection function
+   (`run_collection()` or `collect()`) defines the contract: which
+   endpoints to call, how to paginate, what errors to handle, what
+   response fields to navigate.
+
+2. **`state.json`** — keys matching the future template's `state:`
+   block, with literal test values. The `url` key points at the running
+   mock.
+
+3. **Mock URL** — a running `elastic/stream` mock (already started by
+   the orchestrator). The mock was derived from test-api.py and has been
+   validated against it.
+
+4. **Research brief** (optional supplementary context) — field meanings,
+   data types, edge cases not exercised by the script. The Python source
+   is the primary specification; the brief provides additional
+   requirements (cursor regression guards, rate limit config, etc.).
+
+## Your outputs
+
+1. **A validated `.cel` file** — the CEL expression that mito has
+   validated against the mock at each incremental phase.
+
+2. **A taxonomy classification** — the least complex pattern class that
+   satisfies the API's requirements:
+   - **Pagination:** none | cursor_token | offset | page_number |
+     next_url_in_body | link_header | graphql_relay |
+     worklist_expansion | async_job_polling | export_blob |
+     multi_entity_orchestration
+   - **State management:** stateless | timestamp_cursor | time_window |
+     state_machine | job_cursor
+
+   Classify at the *least complex class*. If cursor_token suffices, do
+   not classify as state_machine. The classification is derived from the
+   Python collection function's loop structure, cursor propagation, and
+   termination conditions.
+
+## First steps — read the skills and references
+
+Before writing any CEL code, read these:
+
+1. **`cel-programs` skill** (SKILL.md) — state management rules, error
+   handling, event output format, pagination strategy selection
+2. **`references/cel-expression.md`** — the expression-specific
+   reference (translation framing, interface contract, core structure,
+   quality checklist)
+3. **`references/cel-taxonomy.md`** — classification dimensions,
+   how to classify from test-api.py, least-complexity principle
+4. **`references/cel-incremental-build.md`** — the phased build ladder
+   you MUST follow and syntax anti-patterns
+5. **`references/cel-code-style.md`** — nesting discipline, flattening
+   techniques
+6. **`references/cel-pagination-patterns.md`** — pagination pattern code
+   (load when writing phase 3)
+7. **`references/mito-reference.md`** — mito CLI flags, execution model
+
+## Workflow
+
+### 1. Analyse test-api.py
+
+Read the collection function. Identify:
+- HTTP method and endpoint construction
+- Authentication header/parameter setup
+- Pagination loop structure and termination condition
+- Response navigation path to the event array
+- Error handling branches (status codes, missing fields, malformed
+  responses)
+- Cursor/state propagation between iterations
+- Initial-vs-subsequent run logic
+
+### 2. Classify the pattern
+
+From the Python code's structure, classify:
+- **Pagination pattern** — what drives the loop? A cursor token? An
+  offset? A next-URL in the body? GraphQL relay?
+- **State management** — how does the script resume? Timestamp cursor?
+  Stateless? State machine?
+
+Choose the *least complex class* that matches the code's behaviour.
+
+### 3. Translate incrementally
+
+Follow the phased build from `references/cel-expression.md`:
+
+**Phase 0 — skeleton:** Translate the basic request structure. The
+Python `do_request()` or `requests.get()` call becomes
+`request("METHOD", url).with({...}).do_request()`. Run mito.
+
+**Phase 1 — error handling:** Translate the Python status code checks.
+Every `if resp.status_code != 200:` becomes a ternary branch. Run mito.
+
+**Phase 2 — event mapping:** Translate the Python response navigation.
+The path `resp["data"]["items"]` becomes `body.data.items`. The
+`for item in items:` loop becomes
+`.map(e, {"message": e.encode_json()})`. Run mito.
+
+**Phase 3 — pagination:** Translate the Python `while` loop. The loop
+condition becomes `want_more`. The cursor update
+(`next_token = resp["meta"]["next"]`) becomes a cursor field. Run mito
+with `-max_executions 5`.
+
+**Phase 4 — cursor guard:** Translate the Python initial-vs-subsequent
+logic. The `if first_run:` branch becomes
+`state.?cursor.field.orValue(default)`. Test with both initial and
+cursor state. Run mito.
+
+**Structural constraint for phase 2 onwards:** After decoding the
+response body, extract all needed fields into a flat intermediate map
+in a single `.as()`, then build the result from that map. Do NOT nest
+multiple `.as()` calls to extract individual fields. See the "Flat
+decode pattern" section in `references/cel-expression.md` for the
+correct shape and worked examples.
+
+At each phase: if mito reports a compilation error, revert to the last
+working version and re-add changes incrementally. Do NOT rewrite from
+scratch.
+
+### 4. Validate fidelity
+
+After phase 4, check the CEL program against test-api.py:
+- Are all error paths in the Python script represented?
+- Does the pagination logic match the Python loop's termination
+  conditions?
+- Are all response fields navigated the same way?
+- Does the cursor state capture the same information Python propagates?
+- Are there Python branches the CEL dropped, or CEL branches Python
+  doesn't have?
+
+If the research brief describes additional requirements not covered by
+the script (e.g., cursor regression guards, empty-page handling), add
+them after the core translation is complete.
+
+### 5. Format and return
+
+Run `celfmt -s -i program.cel -o program.cel` to simplify and format
+the `.cel` file. (`-i` is input, `-o` is output; without `-o` the
+result goes to stdout and the file is unchanged.) Fix any issues it
+reports.
+
+Return:
+- The final `.cel` file content (after formatting)
+- The taxonomy classification
+- The mito command that validated it
+- Which phases were completed and confirmed
+
+## Quality standards
+
+- `.as()` depth <= 5 on every execution path
+- No rate limiting or retry logic
+- Events contain only `{"message": e.encode_json()}`
+- `want_more` driven by pagination signal, not event count
+- No boolean comparisons (`== true`, `== false`)
+- No `bytes()` wrapper on `resp.Body`
+- Cursor defaults use `state.?cursor.field.orValue(...)`
+- Single-use values inlined, not bound with `.as()`
+- All state keys from `state.json` used correctly
+
+## What NOT to do
+
+- Do NOT write `cel.yml.hbs`
+- Do NOT configure manifests
+- Do NOT set up mocks (the orchestrator did this)
+- Do NOT run system tests
+- Do NOT invent API behaviour not present in test-api.py
+- Do NOT add rate limiting, retry, or 429 handling in the CEL program
+- Do NOT set `@timestamp` or any field besides `"message"` in events

--- a/skills/cel-programs/references/mito-reference.md
+++ b/skills/cel-programs/references/mito-reference.md
@@ -19,8 +19,12 @@ stream -version
 ## Core usage
 
 ```bash
-mito -data state.json program.cel
+mito -fb -data state.json program.cel
 ```
+
+The `-fb` flag enables filebeat-compatible config validation. Always
+use it when developing integrations — it catches constraint violations
+(auth, rate limits, state keys) that would fail at runtime.
 
 - `-data <path>` — JSON file with the initial state (exposed as `state` in CEL)
 - `<path>` — file containing the CEL program (must be last argument)
@@ -37,6 +41,7 @@ mito -data <(echo '{"url": "http://localhost:8090"}') <(echo 'get(state.url)')
 
 | Flag | Purpose |
 |------|---------|
+| `-fb` | Validate config against filebeat CEL input constraints (always use for integrations) |
 | `-data <path>` | JSON input exposed as `state` |
 | `-log_requests` | Log HTTP request/response traces to stderr |
 | `-insecure` | Disable TLS certificate verification |
@@ -147,7 +152,7 @@ mito -data state.json program.cel -dump always    # inspect full state per evalu
 mito -data state.json program.cel -insecure       # self-signed TLS
 ```
 
-Validate syntax at any point: `celfmt -s program.cel -o /dev/null`
+Validate syntax at any point: `celfmt -s -i program.cel -o /dev/null`
 
 Test with and without a `cursor` in the input state (first run vs subsequent).
 

--- a/skills/cel-programs/references/reviewer-subagent-guidance.md
+++ b/skills/cel-programs/references/reviewer-subagent-guidance.md
@@ -1,0 +1,134 @@
+# CEL expression reviewer subagent guidance
+
+Operating manual for a subagent that reviews a generated CEL expression
+against complexity baselines and source fidelity. This is structured
+review, not deliberation — the reviewer checks against quantitative
+criteria and the reference implementation.
+
+The orchestrator embeds this file verbatim in your task prompt.
+
+## Your inputs
+
+The orchestrator provides:
+
+1. **The generated `.cel` file** — the CEL expression to review
+2. **The taxonomy classification** — pagination and state management
+   classes assigned by the expression builder
+3. **`ceplx -diag -json` output** — per-node complexity diagnostics
+4. **`test-api.py`** — the Python implementation (the ground truth)
+5. **The research brief** — supplementary context
+
+## Your outputs
+
+A structured review with:
+1. Classification verification (agree/disagree with rationale)
+2. Complexity assessment against baselines
+3. Fidelity assessment against test-api.py
+4. Specific challenges (if any) with evidence
+5. Overall verdict: **accept**, **revise** (with specific changes), or
+   **reject** (with rationale)
+
+## First steps — read the references
+
+1. **`references/cel-complexity-baselines.md`** — the baselines you
+   check against
+2. **`references/cel-taxonomy.md`** — classification dimensions for
+   verification
+3. **`references/cel-expression.md`** — quality checklist
+4. **`references/cel-code-style.md`** — nesting discipline (for
+   refactoring suggestions)
+
+## Review procedure
+
+### Step 1 — verify the taxonomy classification
+
+Read test-api.py's collection function. Independently classify:
+- What drives the pagination loop? → pagination class
+- How does the script resume on next run? → state management class
+
+Compare your classification with the builder's. If they disagree,
+explain why and state which is correct.
+
+### Step 2 — assess complexity against baselines
+
+Look up the program's pattern class in the baselines table.
+
+**Skip threshold:** If cognitive complexity is below the class p50
+**and** below 40, state this and skip to step 3. The program is within
+expected range.
+
+**If above p90:** This is a strong signal. Identify the high-cost nodes
+from the diagnostic output:
+- Which `.as()` chains contribute most?
+- Are there unnecessary bindings that could be inlined?
+- Could pre-bindings reduce nesting?
+- Is there duplicated logic across branches?
+
+**If between p50 and p90:** Note it but don't challenge unless there
+are obvious inefficiencies visible in the diagnostics.
+
+**If the class has n < 10:** Fall back to global percentiles and note
+the small sample.
+
+### Step 3 — assess fidelity to test-api.py
+
+Compare the CEL program against the Python collection function:
+
+1. **Error paths.** List every error branch in the Python script. For
+   each, state whether the CEL program handles it and how. Flag any
+   Python error paths the CEL drops.
+
+2. **Pagination logic.** Compare the Python loop's termination condition
+   with the CEL `want_more` expression. Are they equivalent?
+
+3. **Response navigation.** Trace the Python response field access path
+   (e.g., `resp["data"]["items"]`) and the CEL equivalent (e.g.,
+   `body.data.items`). Flag mismatches.
+
+4. **Cursor state.** Compare what the Python script propagates between
+   iterations with what the CEL stores in `cursor`. Flag missing or
+   extra state.
+
+5. **Invented logic.** Flag any CEL branches that have no corresponding
+   Python logic. The expression builder should not invent behaviour.
+
+### Step 4 — formulate challenges
+
+For each issue found, write a specific challenge:
+
+**Complexity challenge example:**
+> "This is a cursor_token program (n=16). Cognitive complexity is 85,
+> above p90 (49). The diagnostic shows the ternary at `.as(body, ...)`
+> level 3 contributes 40 points. The Python script has a flat
+> `if/elif/else` chain here — can this be flattened with pre-bindings
+> before `state.with()`?"
+
+**Fidelity challenge example:**
+> "The Python script checks `parsed.get('errors')` at line 368 and
+> handles GraphQL errors before navigating to `data.organization`. Your
+> CEL program does not check for GraphQL errors — it goes straight to
+> `body.data.organization`. This drops an error path."
+
+**Unnecessary complexity challenge example:**
+> "The Python script uses `offset += page_size` with a simple
+> `while offset < total` loop. You classified this as `state_machine`
+> but the pattern is plain `offset`. The baseline for offset (cog p50:
+> 47) is lower than state_machine (cog p50: 107)."
+
+### Step 5 — verdict
+
+State one of:
+- **Accept** — program is within baselines and faithful to source
+- **Revise** — list specific changes needed (with line references)
+- **Reject** — fundamental issues requiring a rewrite (rare)
+
+## What NOT to do
+
+- Do NOT rewrite the CEL program yourself
+- Do NOT challenge style preferences that don't affect complexity or
+  correctness
+- Do NOT challenge things the skill explicitly allows (e.g., config-level
+  rate limiting instead of in-program handling)
+- Do NOT require every Python branch if the CEL skill says not to
+  (e.g., 429 handling is config-level, not in-program)
+- Do NOT penalise programs that are below the skip threshold

--- a/skills/research-integration/references/test-api-script-spec.md
+++ b/skills/research-integration/references/test-api-script-spec.md
@@ -295,7 +295,13 @@ if __name__ == "__main__":
 
 ## Relationship to CEL program design
 
-The test script and the proposed CEL program should be two implementations of the same API flow. Specifically:
+The test script is the **ground truth** for CEL program construction. The
+relationship is directional: test-api.py is the source of truth, and the
+CEL program is a **translation** from it. The script has been tested
+against a real API; even if the research brief has inaccuracies, the
+script's behaviour can be accepted as correct.
+
+Specifically:
 
 - **Same endpoints** — the script calls the same API paths the CEL program will use.
 - **Same authentication** — the script uses the same auth mechanism (API key header, OAuth2 token exchange, etc.).
@@ -303,7 +309,18 @@ The test script and the proposed CEL program should be two implementations of th
 - **Same time-based filtering** — the script uses the same time parameters and formats.
 - **Same request construction** — query parameters, headers, and body (if POST) match what the CEL program will send.
 
-The script serves as a validation tool: if it works, the CEL program should work too (modulo Elastic Agent specifics). If it fails, the failure diagnostics in the trace file help debug the issue before any CEL code is written.
+The CEL expression builder receives test-api.py as its primary input and
+translates the collection function (`run_collection()` or equivalent)
+into CEL. The research brief provides supplementary context (field
+meanings, data types, edge cases not exercised by the script), but the
+Python implementation is the specification.
+
+The script also serves as the **mock specification** (the mock is derived
+from the script's request/response flow) and the **mock validator** (the
+script must pass against the mock before CEL translation begins). When a
+`trace.json` exists from a real API run, it acts as an offline **fidelity
+witness** — comparing mock responses against the trace catches cases
+where the mock and script agree but both diverge from real API behaviour.
 
 ## Example reference
 


### PR DESCRIPTION
Extract the CEL expression concern into a dedicated expression-builder subagent that translates test-api.py to CEL via a phased build ladder.
Add a reviewer subagent that checks generated programs against per-pattern-class complexity baselines (from a 316 program ceplx survey) and source fidelity.

New references:
- cel-expression.md: interface contract, flat decode pattern, syntax rules, quality checklist
- cel-taxonomy.md: pagination and state management classification
- cel-complexity-baselines.md: per-class p50/p75/p90 from survey
- expression-builder-subagent-guidance.md: builder operating manual
- reviewer-subagent-guidance.md: reviewer operating manual

Key fixes to existing guidance:
- Place drop_event.when.equals.retry inside processors (not top-level)
- Correct celfmt invocation (-i is input, not in-place flag)
- Add -fb flag to mito for Filebeat-compatible validation
- Reframe test-api.py as translation source, not prose spec

The generate-measure-review-revise loop was validated across 9 vendors.
A single-pass generator cannot self-correct as effectively as a separate reviewer challenging it; the review cycle consistently reduces complexity while preserving fidelity.