### PR TITLE
[anonymize-logs] Mask transaction/sequence/event IDs explicitly

### DIFF
--- a/skills/anonymize-logs/SKILL.md
+++ b/skills/anonymize-logs/SKILL.md
@@ -102,7 +102,7 @@ Use consistent, realistic-looking replacements — not `REDACTED` strings, which
 | Hashed / partial token | replace with full synthetic token of same format |
 | DHCP fingerprint | `example-dhcp-fingerprint-000001` |
 | JA4 fingerprint | replace with same-length hex string |
-| Transaction / sequence / event ID (numeric) | synthetic integer of the **same digit count** — e.g. `48273915` → `10000002` |
+| Transaction / sequence / event ID (numeric) | synthetic integer of the same digit count — e.g. `10000002` |
 | Session / request / correlation ID | same-length synthetic string (preserve length and charset), not a descriptive name |
 
 **Consistency rule**: map identical original values to identical placeholders throughout the file. If the same IP appears 10 times, it must become the same replacement IP all 10 times — so cross-event correlations remain testable.
@@ -128,7 +128,7 @@ If you are unsure what shape to use, look at neighbouring values of the same fie
 
 Do not replace:
 - Protocol names, action verbs, event types, severity levels (`ALLOW`, `DENY`, `INFO`, `ERROR`)
-- HTTP status codes, port numbers, numeric metric values (counts, sizes, durations) — but **not** transaction / sequence / event IDs, which are tracking identifiers and must be masked (see above)
+- HTTP status codes, port numbers, numeric metric values (counts, sizes, durations)
 - Field names and keys
 - Timestamps (format and timezone must stay intact)
 - Structural tokens (brackets, braces, pipes, commas, tabs)

--- a/skills/anonymize-logs/SKILL.md
+++ b/skills/anonymize-logs/SKILL.md
@@ -102,7 +102,7 @@ Use consistent, realistic-looking replacements — not `REDACTED` strings, which
 | Hashed / partial token | replace with full synthetic token of same format |
 | DHCP fingerprint | `example-dhcp-fingerprint-000001` |
 | JA4 fingerprint | replace with same-length hex string |
-| Transaction / sequence / event ID (numeric) | synthetic integer of the same digit count — e.g. `10000002` |
+| Transaction / sequence / event-instance ID (numeric) | synthetic integer matching the original digit count — e.g. `48273915` → `10000002` |
 | Session / request / correlation ID | same-length synthetic string (preserve length and charset), not a descriptive name |
 
 **Consistency rule**: map identical original values to identical placeholders throughout the file. If the same IP appears 10 times, it must become the same replacement IP all 10 times — so cross-event correlations remain testable.
@@ -112,7 +112,7 @@ Use consistent, realistic-looking replacements — not `REDACTED` strings, which
 Every replacement must have the same shape as the original value. The parser and pipeline conditions depend on value format, not just field presence.
 
 - **Numeric ID → numeric ID**: `/d/123/edit` → `/d/456/edit`, not `/d/example-document-id/edit`
-- **Transaction / sequence / event ID → same-shape number**: these are *tracking identifiers*, not metrics — mask them, preserving digit count. e.g. CEF `cn1=48273915 cn2=3061847` → `cn1=10000002 cn2=1000002`
+- **Transaction / sequence / event-instance ID → same-shape number**: when the value is a per-event tracking identifier, mask it, preserving digit count. e.g. CEF `cn1=48273915 cn2=3061847` → `cn1=10000002 cn2=1000002`
 - **UUID → UUID**: a real UUID must become a synthetic UUID of the same version, not a descriptive string
 - **URL → URL**: replace only the sensitive segment (hostname, path ID) — preserve the scheme, path structure, and query string shape
   - `https://docs.google.com/drawings/d/123/edit` → `https://docs.google.com/drawings/d/000000000000/edit` (replace the ID, not the host — `docs.google.com` is a public service name, not an org identifier)
@@ -128,6 +128,7 @@ If you are unsure what shape to use, look at neighbouring values of the same fie
 
 Do not replace:
 - Protocol names, action verbs, event types, severity levels (`ALLOW`, `DENY`, `INFO`, `ERROR`)
+- Product-defined event codes/type IDs, such as Windows event IDs — these describe event semantics, not customer-specific event instances
 - HTTP status codes, port numbers, numeric metric values (counts, sizes, durations)
 - Field names and keys
 - Timestamps (format and timezone must stay intact)

--- a/skills/anonymize-logs/SKILL.md
+++ b/skills/anonymize-logs/SKILL.md
@@ -102,6 +102,8 @@ Use consistent, realistic-looking replacements — not `REDACTED` strings, which
 | Hashed / partial token | replace with full synthetic token of same format |
 | DHCP fingerprint | `example-dhcp-fingerprint-000001` |
 | JA4 fingerprint | replace with same-length hex string |
+| Transaction / sequence / event ID (numeric) | synthetic integer of the **same digit count** — e.g. `48273915` → `10000002` |
+| Session / request / correlation ID | same-length synthetic string (preserve length and charset), not a descriptive name |
 
 **Consistency rule**: map identical original values to identical placeholders throughout the file. If the same IP appears 10 times, it must become the same replacement IP all 10 times — so cross-event correlations remain testable.
 
@@ -110,6 +112,7 @@ Use consistent, realistic-looking replacements — not `REDACTED` strings, which
 Every replacement must have the same shape as the original value. The parser and pipeline conditions depend on value format, not just field presence.
 
 - **Numeric ID → numeric ID**: `/d/123/edit` → `/d/456/edit`, not `/d/example-document-id/edit`
+- **Transaction / sequence / event ID → same-shape number**: these are *tracking identifiers*, not metrics — mask them, preserving digit count. e.g. CEF `cn1=48273915 cn2=3061847` → `cn1=10000002 cn2=1000002`
 - **UUID → UUID**: a real UUID must become a synthetic UUID of the same version, not a descriptive string
 - **URL → URL**: replace only the sensitive segment (hostname, path ID) — preserve the scheme, path structure, and query string shape
   - `https://docs.google.com/drawings/d/123/edit` → `https://docs.google.com/drawings/d/000000000000/edit` (replace the ID, not the host — `docs.google.com` is a public service name, not an org identifier)
@@ -125,7 +128,7 @@ If you are unsure what shape to use, look at neighbouring values of the same fie
 
 Do not replace:
 - Protocol names, action verbs, event types, severity levels (`ALLOW`, `DENY`, `INFO`, `ERROR`)
-- HTTP status codes, port numbers, numeric metric values
+- HTTP status codes, port numbers, numeric metric values (counts, sizes, durations) — but **not** transaction / sequence / event IDs, which are tracking identifiers and must be masked (see above)
 - Field names and keys
 - Timestamps (format and timezone must stay intact)
 - Structural tokens (brackets, braces, pipes, commas, tabs)


### PR DESCRIPTION
## What
Adds explicit guidance + examples for masking numeric **transaction / sequence / event IDs** in the `anonymize-logs` skill.

## Why
The skill already lists "transaction IDs" under *Tracking identifiers* (mask these), but:
- the placeholder table and shape-rule examples had **no numeric-ID example**, and
- *What to preserve* listed "numeric metric values" immediately adjacent,

so a numeric counter (e.g. CEF `cn1`/`cn2`, NetScaler event/transaction IDs) can be misfiled as a "metric" and left unmasked. This actually happened while sanitizing a pipeline fixture — the counters were only caught on a second review pass.

## Harms of numeric IDs

These IDs are often harmless in isolation, but they can act as join keys back to the customer’s real environment. If the same transaction, request, sequence, or event-instance ID appears in support tickets, trace systems, SIEM exports, vendor logs, or another leaked/shared sample, it can tie the public sample back to a real customer event. Some IDs also encode timestamp, shard, tenant, region, or ordering information. For sample logs, we only need the shape and consistency of the value, not the original identifier.

## Changes
- **Placeholder table**: rows for numeric transaction/event IDs (same digit count) and opaque session/correlation IDs (same length/charset).
- **Shape rule**: worked example `cn1=48273915 cn2=3061847` → `cn1=10000002 cn2=1000002` (digit-count preserved; flagged as tracking IDs, not metrics).
- **What to preserve**: clarifies product-defined event codes or numeric *metrics* (counts, sizes, durations) are kept, in contrast to transaction/sequence/event IDs.

All example values are fabricated.

🤖 Generated using Claude Code and Codex under my supervision