### PR TITLE
Add Claude Code plugin marketplace manifests

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -19,6 +19,13 @@ steps:
     if_changed:
       - "catalog-info.yaml"
 
+  - label: "Validate Claude Code plugin manifests"
+    command: "npx @anthropic-ai/claude-code@latest plugin validate ."
+    agents:
+      image: "docker.elastic.co/ci-agent-images/pipelib:0.27.0@sha256:d1713778d27e0b6208f59ba8761f04ef033af4c4237cb2614a09d38584c5ff88"
+    if_changed:
+      - ".claude-plugin/**"
+
   - label: ":pipeline: Upload default Pipeline"
     command: "buildkite-agent pipeline upload .buildkite/default-pipeline.yml"
     if_changed:

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,12 @@
+{
+  "name": "elastic-integration-skills",
+  "owner": { "name": "Elastic" },
+  "description": "Elastic skills for Claude Code.",
+  "plugins": [
+    {
+      "name": "integration-skills",
+      "source": ".",
+      "description": "Build, review, and maintain Elastic integration packages."
+    }
+  ]
+}

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,12 @@
+{
+  "name": "integration-skills",
+  "displayName": "Elastic Integration Skills",
+  "description": "Agentic workflows for building, reviewing, and maintaining Elastic integration packages.",
+  "version": "1.0.0",
+  "author": { "name": "Elastic" },
+  "homepage": "https://github.com/elastic/integration-skills",
+  "repository": "https://github.com/elastic/integration-skills",
+  "license": "Apache-2.0",
+  "keywords": ["elastic", "integrations", "ecs", "cel", "ingest-pipelines"],
+  "skills": "./skills/"
+}

--- a/README.md
+++ b/README.md
@@ -101,6 +101,21 @@ npx skills add elastic/integration-skills --all
 | --all | Install all skills to all agents without prompts |
 | --list | List available skills without installing |
 
+### Claude Code (plugin marketplace)
+
+If you use [Claude Code](https://claude.ai/code), you can install the skills natively through the Claude Code plugin marketplace. This path supports `autoUpdate`, so your local copy stays current whenever the skills are updated upstream.
+
+**Register the marketplace and install the plugin:**
+
+```
+/plugin marketplace add elastic/integration-skills
+/plugin install integration-skills@elastic-integration-skills
+```
+
+Once installed, skills are namespaced under the plugin name when invoked explicitly (e.g. `/integration-skills:create-integration`). They still trigger automatically from their descriptions, so you can also just describe what you want and the agent picks the right skill.
+
+**Auto-update:** After installation, Claude Code keeps the plugin current in the background. No manual `npx skills update` step needed.
+
 ### Local clone
 
 If you prefer to work from a local checkout, or your environment does not have Node.js / npx, clone the repository and copy the `skills/` folder into the config directory your agent expects:


### PR DESCRIPTION
## Proposed commit message

```
Add Claude Code plugin marketplace manifests

The npx install path copies skill files into a local directory. Those
files go stale and users must remember to run npx skills check to
detect drift. Claude Code's native plugin system installs and updates
skill bundles without that manual step.

Add .claude-plugin/plugin.json to declare the integration-skills
plugin and point Claude Code at ./skills/ for skill content. Add
.claude-plugin/marketplace.json to register the elastic-integration-skills
namespace so contributors can run:

  /plugin marketplace add elastic/integration-skills
  /plugin install integration-skills@elastic-integration-skills

Claude Code then manages updates automatically on each version bump.

Document the new path in the README between the npx and local-clone
sections. Add a Buildkite step that runs claude plugin validate when
.claude-plugin/ changes.
```

Relates #10