### PR TITLE
docs: document replacing changelog placeholder link with real PR number

### DIFF
--- a/skills/create-integration/references/create-workflow.md
+++ b/skills/create-integration/references/create-workflow.md
@@ -251,3 +251,4 @@ Ensure subagents receive this instruction: all fixture data, mock API responses,
 - **Never include `data_stream.dataset` in `cel.yml.hbs` or as a manifest var for integration packages** (`type: integration`). The framework routes documents automatically. Only input-type packages (`type: input`) use this field. Setting it in an integration package overrides routing and causes "0 hits" in system tests.
 - Set version to `0.1.0` for new integrations.
 - Do not load domain-specific skills (CEL, pipelines, ECS, field mappings) into your own context. Delegate to subagents.
+- This workflow does not cover opening the PR. Once a PR exists, `changelog.yml`'s placeholder link (`pull/99999`) must be replaced with the real PR number and pushed before merge -- see `package-spec` skill's "Updating the changelog link after PR creation".

--- a/skills/maintain-integration/references/improve-workflow.md
+++ b/skills/maintain-integration/references/improve-workflow.md
@@ -205,5 +205,6 @@ After subagent fixes complete, re-run `elastic-package check` and re-launch the 
 - When fixing pipelines, preserve existing processor logic that works correctly.
 - When adding field mappings, follow the ECS mapping strategy already in use by the package.
 - Update `changelog.yml` when the changes are user-visible (follow `package-spec` skill).
+- Once the PR for these changes exists, replace `changelog.yml`'s placeholder link (`pull/99999`) with the real PR number and push before merge -- see `package-spec` skill's "Updating the changelog link after PR creation".
 - If a fix requires decisions the user hasn't made (auth method, field naming, categorization), mark it as a TODO rather than guessing.
 - Do not load domain-specific skills (CEL, pipelines, ECS, field mappings) into your own context. Delegate to subagents.

--- a/skills/package-spec/SKILL.md
+++ b/skills/package-spec/SKILL.md
@@ -135,8 +135,27 @@ Edit `changelog.yml` directly, or use `elastic-package changelog add` (see `elas
 - Adding the entry under the wrong version or not at the top
 - Missing `link` field -- `elastic-package lint` validates that the PR/issue number is a positive integer and **rejects** `pull/0`; use a real PR number or `pull/99999` as a development placeholder and replace before merge
 - Bumping manifest/package version inconsistently with changelog intent
+- **Forgetting to swap the placeholder link back in** -- see below
 
 See `references/changelog-patterns.md` for detailed patterns, breaking-change checklist, and CI examples.
+
+## Updating the changelog link after PR creation
+
+The changelog `link` field must point to the PR that introduces the change, but the
+real PR number is only known once a PR has actually been opened -- everything up to
+that point necessarily uses the `pull/99999` placeholder from the pitfall above. This
+step is easy to skip because it happens *after* the rest of the package work is done,
+outside the usual build/test loop.
+
+Once the PR exists on GitHub:
+
+1. Get the real PR number (from `gh pr create` output or the PR URL).
+2. In `changelog.yml`, replace every placeholder link
+   (`https://github.com/elastic/integrations/pull/99999`) with
+   `https://github.com/elastic/integrations/pull/<real-number>`.
+3. Run `elastic-package lint` to confirm the link now validates.
+4. Commit and push the update to the same PR branch -- the placeholder must not be
+   present in the version that gets merged.
 
 ---
 

--- a/skills/review-integration/references/reviewer-subagent-guidance.md
+++ b/skills/review-integration/references/reviewer-subagent-guidance.md
@@ -192,6 +192,14 @@ changelog links (`pull/0`) and placeholder logos/icons are
 MEDIUM or HIGH. For subsequent versions, the same placeholders are
 real findings (MEDIUM or HIGH as appropriate).
 
+**Exception -- the `pull/99999` development placeholder.** Leniency
+does not apply to it, at any package version: flag it at **MEDIUM**.
+Unlike `pull/0`, `pull/99999` passes `elastic-package lint`, so
+nothing else catches it and it silently reaches merge as a dead
+changelog link. The fix is to replace it with the real PR number
+once the PR exists -- see the `package-spec` skill's "Updating the
+changelog link after PR creation".
+
 ### CEL-specific operating rules
 
 When CEL input is in scope, the `review-integration` skill requires

--- a/skills/review-integration/references/severity-rubric.md
+++ b/skills/review-integration/references/severity-rubric.md
@@ -38,6 +38,7 @@ These severities apply to **new packages**. For existing packages, see the "Revi
 | Manifest | format_version too low for features used | HIGH |
 | Manifest | conditions.kibana.version too low for agent features used | HIGH |
 | Manifest | Data stream duplicates root manifest fields | MEDIUM |
+| Changelog | `pull/99999` development placeholder link not replaced with the real PR number | MEDIUM |
 | Tests | No pipeline test fixtures | HIGH |
 | Tests | Missing test-common-config.yml | HIGH |
 | Input | Hardcoded credentials | CRITICAL |


### PR DESCRIPTION
## Summary
- `package-spec` already tells contributors to use `pull/99999` as a placeholder `link` in `changelog.yml` while a PR doesn't exist yet, but no skill says what to do once the PR *does* exist -- the placeholder needs to be swapped for the real PR number and pushed before merge.
- Adds a "Updating the changelog link after PR creation" section to `package-spec/SKILL.md` with the concrete steps (get PR number, edit `changelog.yml`, re-lint, push).
- Adds a one-line pointer to that section from the `create-integration` and `maintain-integration` workflow guardrails, since neither workflow currently has a PR-creation step to hang this off of.

## Motivation
Without this, an agent (or contributor) following these skills has no prompt to go back and fix the changelog link after opening the PR, so placeholder links can slip into merged changelogs.

## Test plan
- [ ] Docs-only change; no build/lint required beyond reviewing rendered markdown