### PR TITLE
Add federate-aws-integration skill

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -15,6 +15,7 @@
         "./skills/dashboard-review",
         "./skills/ecs-field-mappings",
         "./skills/elastic-package-cli",
+        "./skills/federate-aws-integration",
         "./skills/ingest-pipelines",
         "./skills/input-configurations",
         "./skills/integration-testing",

--- a/README.md
+++ b/README.md
@@ -183,6 +183,7 @@ In addition to the top-level skills, you can invoke any domain skill directly wh
 | `/package-spec` | Manifest rules, changelog schema, format version features |
 | `/integration-testing` | Pipeline testing, system testing, test fixture authoring |
 | `/elastic-package-cli` | `elastic-package` CLI usage and troubleshooting |
+| `/federate-aws-integration` | Enable Federated Identity (Cloud Connectors) on an agentless-eligible AWS integration package |
 | `/dashboard-guidelines` | Kibana dashboard authoring standards |
 | `/dashboard-review` | Kibana dashboard review procedures |
 | `/anonymize-logs` | Test data anonymization conventions |

--- a/skills/federate-aws-integration/SKILL.md
+++ b/skills/federate-aws-integration/SKILL.md
@@ -583,3 +583,83 @@ add a separate changelog entry for it.
 **elastic/kibana PR** (only if joining a policy group, §5):
 - [ ] Adds package to `CLOUD_CONNECTOR_PERMISSION_ALLOWLIST`
 - [ ] Links to the integrations PR
+
+**elastic/cloudbeat PR** (the §3.1 CFT mirror):
+- [ ] One PR per integration, stacked on the incremental-baseline PR
+- [ ] Links to the integrations PR whose `provider_permissions` it mirrors
+
+---
+
+## 9 — Human validation handoff (generate this, always)
+
+End every run by producing a checklist **tailored to the target package** for
+the human to work through. The sections below define what it must cover;
+research the package-specific answers — never emit generic placeholders.
+
+### 9.1 Permission claims to verify
+
+For **every IAM action** declared in §3, list:
+
+- The action, the API call it authorizes (from the CEL program / hbs / beats
+  module), and the **primary-source citation** (AWS API reference page).
+- Any action whose name differs from the API operation name, flagged
+  prominently. These are the silent killers — e.g. Security Hub's
+  `GetFindingsV2` operation authorizes as `securityhub:GetFindings`; a
+  reviewer who "corrects" it to `securityhub:GetFindingsV2` breaks the role.
+- Whether the set is least-privilege: no action the collector doesn't call,
+  no `*` wildcards, `Resource: '*'` justified (most read/list APIs are not
+  resource-scopable — say so explicitly if that's the justification).
+
+### 9.2 Cross-PR consistency to verify
+
+- The IAM actions in the integrations PR's `provider_permissions`, the
+  cloudbeat PR's CFT policy, and (once live) the IaCP-rendered template are
+  **identical sets** — a drift between them means the fallback and primary
+  paths grant different permissions.
+- `iac_template_url` version segment matches the package's Kibana floor
+  minor.
+- Merge order documented: hygiene PR (if any) → integrations PR; CFT baseline
+  → CFT per-integration PR; the fallback URL 404s until the CFT publishes.
+
+### 9.3 End-to-end test plan (research the data path)
+
+Spell out concretely how to make the integration produce data — the AWS-side
+setup a tester must perform, not just the Kibana-side clicks:
+
+1. **Prerequisite AWS resources**: what must be enabled/created in the test
+   account (the service itself, detectors/hubs/standards, source resources).
+2. **Event generation**: what has to *happen* for ingestible records to
+   exist — findings only appear if something generates them. Name the
+   fastest trigger (sample findings, a deliberately noncompliant resource,
+   a scheduled scan).
+3. **Latency expectations**: how long after the trigger until the API
+   returns data, so a tester doesn't declare failure prematurely.
+4. **Where to look in Kibana**: the exact target data stream
+   (`logs-<package>.<stream>-<namespace>` or metrics equivalent) and one
+   field to sanity-check.
+5. **Failure probes**: what an authorization failure looks like in agent
+   logs (e.g. `AccessDeniedException` naming the missing action) vs. an
+   empty-but-authorized result.
+
+Worked example for `aws_securityhub`:
+
+> 1. Enable Security Hub in the test account/region; enable at least one
+>    standard (AWS Foundational Security Best Practices) so controls run.
+> 2. Fastest data: Security Hub generates findings from the enabled
+>    standard's automated checks within ~2h of enablement; deliberately
+>    noncompliant resources (e.g. an unencrypted S3 bucket) accelerate
+>    real findings. GuardDuty sample findings also flow in if GuardDuty
+>    integration is on.
+> 3. First control-check findings typically minutes-to-hours after
+>    enabling a standard; budget 2h before concluding failure.
+> 4. Kibana: `logs-aws_securityhub.finding-*`; sanity-check
+>    `aws_securityhub.finding.class_uid` is populated.
+> 5. Auth failure: agent CEL log shows HTTP 403 with
+>    `AccessDeniedException` on `POST /findingsv2`; authorized-but-empty
+>    returns HTTP 200 with `"Findings": []`.
+
+### 9.4 Open assumptions
+
+Restate anything the run marked unverified (e.g. the Fleet UI input-level
+var_groups rendering assumption from §0.3) so the human knows what hasn't
+been proven, not just what has.

--- a/skills/federate-aws-integration/SKILL.md
+++ b/skills/federate-aws-integration/SKILL.md
@@ -184,6 +184,28 @@ actually supports AWS authentication:
 - If `deployment_modes.agentless.enabled: true` already exists on the target
   policy templates, skip §1.4.
 
+### 0.5 Find tests that assert the behavior you are about to remove
+
+Check the data stream's `_dev/test/` for tests coupled to the pre-migration
+auth behavior — they pass locally (lint/build don't run them) and then fail
+in CI:
+
+- **`scripts/`**: script tests asserting a hand-rolled credential gate's
+  error message. Precedent: `aws/config`'s `missing_credentials` test
+  asserted "access_key_id and secret_access_key required" — a message the
+  auth.aws migration deletes. Rewrite such tests to the new contract: the
+  unauthenticated request fails at the AWS API and the program surfaces its
+  own stable error wrapper as an error event (assert the wrapper prefix, not
+  the environment-dependent AWS exception text), with no data events.
+- **`policy/`**: rendered-policy snapshots that embed the old hbs output
+  (manual `Authorization`/`X-Amz-Date` transforms, creds-in-state). Any
+  snapshot containing the signing machinery goes stale the moment the hbs
+  changes — regenerate it.
+
+```bash
+grep -rl "access_key\|Authorization\|X-Amz" packages/<pkg>/data_stream/<stream>/_dev/test/
+```
+
 ---
 
 ## 1 — Package `manifest.yml` changes

--- a/skills/federate-aws-integration/SKILL.md
+++ b/skills/federate-aws-integration/SKILL.md
@@ -624,7 +624,14 @@ For **every IAM action** declared in §3, list:
 ### 9.3 End-to-end test plan (research the data path)
 
 Spell out concretely how to make the integration produce data — the AWS-side
-setup a tester must perform, not just the Kibana-side clicks:
+setup a tester must perform, not just the Kibana-side clicks. **Embed this
+plan in the integrations PR body as an `## E2E test plan` section** (not just
+in the handoff to the user): reviewers and testers must see it without
+hunting through comments, and the hold-merge gate references it. Start the
+section by naming what the run uniquely proves (e.g. that the `auth.aws`
+signer handles the program's request shape against real AWS — mocks don't
+verify signatures), and end it with a regression line covering the legacy
+credential paths the change touches.
 
 1. **Prerequisite AWS resources**: what must be enabled/created in the test
    account (the service itself, detectors/hubs/standards, source resources).

--- a/skills/federate-aws-integration/SKILL.md
+++ b/skills/federate-aws-integration/SKILL.md
@@ -1,0 +1,462 @@
+---
+name: federate-aws-integration
+description: >
+  Enable Federated Identity (Cloud Connectors) on an agentless-eligible AWS
+  integration package in elastic/integrations. Use when asked to "add federation
+  to <package>", "enable Identity Federation on <package>", or to repeat the
+  pattern proven on the `aws` package for another AWS integration. Template
+  generation is handled by the IaC Provider (IaCP) — no static CFT URL is used.
+  Produces manifest edits, provider_permissions declarations, agent-template
+  patches, a changelog entry, and a validation checklist.
+license: Apache-2.0
+metadata:
+  author: elastic
+  version: "1.0"
+---
+
+# federate-aws-integration
+
+## When to use
+
+Use this skill when tasks include:
+- Adding Federated Identity (Cloud Connectors) auth to an agentless AWS integration package
+- Enabling agentless deployment on a package as a prerequisite for federation
+- Repeating the var_groups / auth.aws / provider_permissions pattern proven on the `aws` package
+- Determining whether a package's inputs are eligible for federation
+
+Template generation is IaC Provider (IaCP)-driven. The `cloud-iac-provisioner`
+service renders IAM role templates dynamically at onboard time from the
+package's declared `provider_permissions`. Do **not** add a static
+CloudFormation quick-create URL (`iac_template_url`) for packages added via
+this skill — that belongs to the older static-CFT flow.
+
+> **Warning when reading the `aws` package as a reference:** its
+> `identity_federation` var_groups option carries an `iac_template_url`
+> pointing at a static GuardDuty CFT. That is the legacy flow — do not copy
+> that key into new packages.
+
+## Background
+
+- Pattern source: the `aws` package (var_groups landed in elastic/integrations#19828)
+- Kibana IaCP broker route: `POST /internal/fleet/iac_provider/render_template`
+- Tracking (2026): elastic/ingest-dev#8812 (per-package rollout), elastic/ingest-dev#8804 (this skill)
+
+---
+
+## 0 — Pre-flight checks
+
+Before touching any file, run these checks and stop with an explanation if any fail.
+
+### 0.1 Fetch the package manifest
+
+```bash
+cat packages/<PACKAGE>/manifest.yml
+```
+
+Confirm:
+
+| Check | Required | Why |
+|---|---|---|
+| `format_version` | `>= 3.6.4` | `var_groups` requires 3.6.0; `provider_permissions` requires 3.6.4 |
+| `conditions.kibana.version` | `^9.4.0` or higher | `auth.aws` requires Agent 9.4.0+ |
+| `conditions.agent.version` | `^9.4.0` or higher | same |
+
+Constraints that are too low get bumped as part of §1 — note them now.
+
+### 0.2 Identify agentless-eligible inputs
+
+Only these input types can run agentless and therefore support federation:
+
+- `cel`
+- `httpjson`
+- `aws/metrics` (any `*metrics` variant)
+- `aws-cloudwatch`
+
+**Not eligible:** `aws-s3`, `awsfargate/metrics`, and any other unlisted type.
+
+For each policy template, list every input and mark it eligible (E) or
+ineligible (I). You will use this list in §2, §3, and §4.
+
+If **no** inputs are eligible, federation cannot be added — stop and report.
+
+### 0.3 Audit the credential vars
+
+Find where the AWS auth vars are declared. Packages differ:
+
+- **Package level** (top-level `vars:`) — e.g. the `aws` package
+- **Input level** (`policy_templates[].inputs[].vars`) — e.g. `aws_securityhub`
+
+`var_groups` options may reference vars declared at any of these levels (the
+package-spec validator collects package, policy_template, and input vars).
+Record which shape this package uses — §1 depends on it.
+
+Then classify every existing credential var into one of four buckets:
+
+| Bucket | Vars | Fate |
+|---|---|---|
+| **Federation-required** | `role_arn`, `external_id` | Must exist — add any that are missing (§1.1). `supports_identity_federation` is always added new. |
+| **Agentless-compatible** | `access_key_id`, `secret_access_key` | Kept; form the `direct_access_key` option, visible in both modes. |
+| **Agent-only** | `session_token`, `shared_credential_file`, `credential_profile_name` | Kept; grouped into options with `hide_in_deployment_modes: [agentless]` (§1.2). |
+| **Auxiliary / non-credential** | `assume_role_duration`, `assume_role_expiry_window`, `proxy_url`, `ssl`, ... | Left outside `var_groups` entirely — they are tuning knobs, not credential selectors. |
+
+The output of this audit drives §1.1 (what to add) and §1.2 (which var_group
+options to emit). If federation-required vars are missing, copy their
+definitions from the `aws` package (same names, types, `show_user: false`,
+`required: false` — the var_group controls requirement).
+
+> **Unverified assumption:** the package-spec validator accepts input-level
+> var references, but Fleet UI rendering of var_groups against input-level
+> vars has not been end-to-end verified. If the UI misbehaves, fall back to
+> hoisting the auth vars to the package level.
+
+### 0.4 Check for existing structures
+
+- If `var_groups:` already exists, skip §1.2.
+- If `supports_identity_federation` already exists as a var, skip §1.1.
+- If `deployment_modes.agentless.enabled: true` already exists on the target
+  policy templates, skip §1.4.
+
+---
+
+## 1 — Package `manifest.yml` changes
+
+### 1.1 Add missing federation vars
+
+Add these **alongside the existing auth vars** (same level — package or input,
+per §0.3), after the last auth var.
+
+Always add:
+
+```yaml
+  - name: supports_identity_federation
+    type: bool
+    title: Supports Identity Federation
+    multi: false
+    required: false
+    show_user: false
+```
+
+If the §0.3 audit found `role_arn` or `external_id` missing, add them too:
+
+```yaml
+  - name: role_arn
+    type: text
+    title: Role ARN
+    multi: false
+    required: false
+    show_user: false
+  - name: external_id
+    type: text
+    title: External ID
+    multi: false
+    required: false
+    show_user: false
+    secret: true
+    description: External ID to use when assuming a role in another account, see [the AWS documentation for use of external IDs](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_create_for-user_externalid.html)
+```
+
+### 1.2 Add `var_groups`
+
+After the `vars:` list (or after `format_version`-level metadata if there are
+no package vars) and before `policy_templates:`, add:
+
+```yaml
+var_groups:
+  - name: credential_type
+    required: true
+    title: Setup Access
+    selector_title: Preferred method
+    options:
+      - name: identity_federation
+        title: Identity Federation
+        vars: [role_arn, external_id, supports_identity_federation]
+        hide_in_deployment_modes: [default]
+        provider: aws
+      - name: direct_access_key
+        title: Direct Access Keys
+        vars: [access_key_id, secret_access_key]
+      - name: temporary_access_key
+        title: Temporary Access Keys
+        vars: [access_key_id, secret_access_key, session_token]
+        hide_in_deployment_modes: [agentless]
+      - name: assume_role
+        title: Assume Role
+        vars: [role_arn]
+        hide_in_deployment_modes: [agentless]
+      - name: assume_role_external_id
+        title: Assume Role with External ID
+        vars: [role_arn, external_id]
+        hide_in_deployment_modes: [agentless]
+      - name: shared_credentials
+        title: Shared Credentials
+        vars: [shared_credential_file, credential_profile_name]
+        hide_in_deployment_modes: [agentless]
+```
+
+Build the options list from the §0.3 audit, not by copying blindly:
+
+- Emit only options whose vars the package actually declares (e.g. drop
+  `shared_credentials` if there is no `shared_credential_file` var).
+- Every **agent-only** option carries `hide_in_deployment_modes: [agentless]`
+  — that is the grouping for agent-based deployments. Users on the default
+  (agent) path keep every credential method they had before; agentless users
+  see only Identity Federation and Direct Access Keys.
+- **Auxiliary** vars from the audit (`assume_role_duration`, `proxy_url`,
+  `ssl`, ...) stay outside `var_groups` — do not force them into an option.
+- If the package has extra credential vars that don't match any canonical
+  option (rare), propose a new agent-only option named after the credential
+  method, with `hide_in_deployment_modes: [agentless]`, and flag it for
+  reviewer attention in the PR.
+
+Rules enforced by the package-spec validator:
+- Every name in `options[].vars` must exist as a var (any level).
+- Vars referenced by a var_group **must not have `required: true`** —
+  requirement is controlled by the var_group itself.
+
+Note: `iac_template_url` is intentionally omitted from `identity_federation`.
+Template generation is handled by the IaC Provider at onboard time.
+
+### 1.3 Bump `format_version` and conditions
+
+- `format_version: 3.6.4` (or newer)
+- Conditions floor:
+
+```yaml
+conditions:
+  kibana:
+    version: "^9.4.0"
+  # auth.aws support in CEL and HTTPJSON inputs requires Elastic Agent 9.4.0+.
+  agent:
+    version: "^9.4.0"
+```
+
+### 1.4 Refactor for agentless deployment (if not already enabled)
+
+Federation is only offered on the agentless path. If the package has no
+agentless support yet, refactor it:
+
+**a. Enable agentless on each target policy template:**
+
+```yaml
+    deployment_modes:
+      default:
+        enabled: true
+      agentless:
+        enabled: true
+        release: beta             # or ga; evaluated in Kibana 9.5.0+
+        organization: <org>       # e.g. security
+        division: engineering
+        team: <owning-team>       # from CODEOWNERS
+```
+
+Optional fields: `is_default: true` (make agentless the default mode when both
+are offered) and `resources.requests.{memory,cpu}` if the workload needs more
+than the platform default.
+
+**b. Restrict ineligible inputs to agent-based mode.** When a policy template
+mixes eligible and ineligible inputs (per §0.2), pin each ineligible input
+with input-level `deployment_modes`:
+
+```yaml
+      - type: aws-s3
+        title: Collect <Package> logs from AWS S3 or SQS
+        description: Collecting <Package> logs via AWS S3/SQS.
+        deployment_modes: ["default"]
+```
+
+Inputs without this key are offered in all deployment modes — leave eligible
+inputs unrestricted.
+
+Enabling agentless is itself a reviewable product decision — the owning team
+commits to operating fully-managed deployments of this integration. Call it
+out explicitly in the PR description rather than burying it in the federation
+change, and get the owning team's sign-off before shipping.
+
+---
+
+## 2 — Policy template input gating
+
+For every **ineligible** input (from §0.2) inside every policy template, add
+`hide_in_var_group_options` directly under the input's `description` line:
+
+```yaml
+      - type: aws-s3
+        title: Collect <Package> logs from AWS S3 or SQS
+        description: Collecting <Package> logs via AWS S3/SQS.
+        hide_in_var_group_options:
+          credential_type: [identity_federation]
+```
+
+Leave eligible inputs (`cel`, `httpjson`, `aws/metrics`, `aws-cloudwatch`)
+without this key — they must remain visible when Identity Federation is selected.
+
+**Two distinct gates — don't conflate them:**
+
+| Situation | Mechanism |
+|---|---|
+| Input runs agentless but doesn't support federation (e.g. `aws-s3` with access keys) | `hide_in_var_group_options: credential_type: [identity_federation]` (this section) |
+| Input can't run agentless at all | `deployment_modes: ["default"]` on the input (§1.4b) |
+
+An input pinned to `["default"]` never sees the Identity Federation option
+anyway (it's hidden in default mode), so it doesn't also need the
+`hide_in_var_group_options` gate.
+
+---
+
+## 3 — Declare `provider_permissions`
+
+The IaCP renders the IAM role template from these declarations — they are the
+source of truth for what the generated role can do. Requires
+`format_version >= 3.6.4`.
+
+`provider_permissions` may be declared at package, policy_template, input, and
+data_stream levels; entries across levels are accumulated and deduplicated.
+Declare each permission at the **narrowest level that needs it**:
+
+```yaml
+# Input-level example (aws_securityhub's cel input):
+      - type: cel
+        title: Collect AWS Security Hub logs via API
+        description: Collecting AWS Security Hub logs via API.
+        provider_permissions:
+          - provider: aws
+            description: Security Hub read access for findings collection.
+            permissions:
+              - name: securityhub:GetFindings
+```
+
+Optional `roles` attach managed policies alongside inline permissions:
+
+```yaml
+        provider_permissions:
+          - provider: aws
+            description: Read-only security auditing.
+            roles:
+              - name: SecurityAudit
+                id: arn:aws:iam::aws:policy/SecurityAudit
+            permissions:
+              - name: securityhub:GetFindings
+```
+
+To determine the correct IAM actions, check the input's actual API calls
+(agent stream template, CEL program, or beats module docs) — do not guess.
+Prefer the minimal read-only set.
+
+---
+
+## 4 — Agent stream template (`*.yml.hbs`) changes
+
+For each eligible input's agent stream template at
+`data_stream/<name>/agent/stream/<input>.yml.hbs`, append the federation hook
+at the very end of the `auth.aws:` block:
+
+```handlebars
+auth.aws:
+{{#if access_key_id}}
+  access_key_id: {{access_key_id}}
+{{/if}}
+{{#if secret_access_key}}
+  secret_access_key: {{secret_access_key}}
+{{/if}}
+{{#if session_token}}
+  session_token: {{session_token}}
+{{/if}}
+{{#if shared_credential_file}}
+  shared_credential_file: {{shared_credential_file}}
+{{/if}}
+{{#if credential_profile_name}}
+  credential_profile_name: {{credential_profile_name}}
+{{/if}}
+{{#if role_arn}}
+  role_arn: {{role_arn}}
+{{/if}}
+{{#if external_id}}
+  external_id: {{external_id}}
+{{/if}}
+{{#if assume_role_duration}}
+  assume_role.duration: {{assume_role_duration}}
+{{/if}}
+{{#if assume_role_expiry_window}}
+  assume_role.expiry_window: {{assume_role_expiry_window}}
+{{/if}}
+{{#if supports_identity_federation}}
+  use_cloud_connectors: {{supports_identity_federation}}
+{{/if}}
+```
+
+If the template already has an `auth.aws:` block, append only the final
+three-line `{{#if supports_identity_federation}}` block. If there is no
+`auth.aws:` block, add the entire block, trimming `{{#if}}` clauses for vars
+the package doesn't declare.
+
+---
+
+## 5 — Kibana policy-group membership (conditional)
+
+Kibana's Fleet plugin keeps `CLOUD_CONNECTOR_PERMISSION_ALLOWLIST`
+(`x-pack/platform/plugins/shared/fleet/common/constants/cloud_connector.ts`).
+This is **not a render gate** — a package absent from it still renders fine,
+standalone, with its own cloud connector.
+
+What it controls is **connector sharing**: integrations in the same policy
+group share one cloud connector, so the rendered template must grant the whole
+group's permissions at once.
+
+- **New package should have its own standalone connector** (the default):
+  no Kibana change needed. Skip this section.
+- **New package should share a connector with an existing group** (e.g. join
+  `aws_global_policy_group`): open a Kibana PR adding an entry:
+
+```typescript
+aws_global_policy_group: [
+  { provider: AWS_CLOUD_PROVIDER, package: 'aws', policyTemplate: 'guardduty' },
+  { provider: AWS_CLOUD_PROVIDER, package: '<package>', policyTemplate: '<policy_template>' },
+],
+```
+
+If in doubt, ship standalone first — group membership can be added later.
+
+---
+
+## 6 — Changelog entry
+
+Bump the package **minor version** (e.g. `1.2.0` → `1.3.0`) and prepend to
+`changelog.yml`:
+
+```yaml
+- version: "X.Y.0"
+  changes:
+    - description: Enable Identity Federation (Cloud Connectors) authentication for agentless deployments.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/<PR_NUMBER>
+```
+
+Also update `version:` in `manifest.yml` to match. If §1.4 enabled agentless,
+add a separate changelog entry for it.
+
+---
+
+## 7 — Validation checklist
+
+- [ ] `elastic-package lint` — no errors (validates var_groups references and provider_permissions shape)
+- [ ] `elastic-package build` — package builds cleanly
+- [ ] The Fleet UI agentless path shows the Identity Federation credential option
+- [ ] The Fleet UI default path hides the Identity Federation option
+- [ ] Ineligible inputs (`aws-s3`, etc.) do not appear when Identity Federation is selected
+- [ ] On serverless, onboard via Identity Federation: IaCP renders the IAM role template from the declared provider_permissions, user deploys, data arrives in the target data stream
+- [ ] Deployed role's policy matches the declared provider_permissions (no missing actions at collection time)
+
+---
+
+## 8 — PR checklist
+
+**elastic/integrations PR:**
+- [ ] Title: `[<package>] Enable Identity Federation for agentless deployments`
+- [ ] Body links to the tracking issue for the rollout
+- [ ] Agentless enablement (if part of this PR) called out explicitly
+- [ ] `changelog.yml` entry added with correct version bump
+- [ ] CODEOWNERS confirmed for this package
+
+**elastic/kibana PR** (only if joining a policy group, §5):
+- [ ] Adds package to `CLOUD_CONNECTOR_PERMISSION_ALLOWLIST`
+- [ ] Links to the integrations PR

--- a/skills/federate-aws-integration/SKILL.md
+++ b/skills/federate-aws-integration/SKILL.md
@@ -83,6 +83,16 @@ Constraints that are too low get bumped as part of §1 — note them now.
 > This needs sign-off from every team in the package's CODEOWNERS before any
 > constraint changes.
 
+> **Expect new validators to fire on old files.** A `format_version` jump can
+> activate stricter semantic validation (e.g. pipeline processors requiring
+> `tag`, `on_failure` message format) against files this skill never touches.
+> Before making any federation edits, apply only the `format_version` bump
+> and run `elastic-package lint` to size the cleanup — on `aws_securityhub`,
+> the 3.5.0 → 3.6.4 bump surfaced 514 pre-existing pipeline violations. Land
+> those as a separate mechanical "pipeline hygiene" PR first (precedent:
+> elastic/integrations#19824 for the `aws` package), then rebase the
+> federation change on top.
+
 ### 0.2 Identify agentless-eligible inputs
 
 Only these input types can run agentless and therefore support federation:

--- a/skills/federate-aws-integration/SKILL.md
+++ b/skills/federate-aws-integration/SKILL.md
@@ -63,6 +63,26 @@ Confirm:
 
 Constraints that are too low get bumped as part of §1 — note them now.
 
+> **Escalation: the bump would abandon users on a supported stack.** If the
+> current Kibana constraint covers a stack line that the new `^9.4.0` floor
+> drops (e.g. `^8.16.5 || ^9.0.0` — all 8.x users lose updates), do NOT bump
+> silently; that is a product decision. Report it and suggest the branching
+> strategy from elastic/ingest-dev#8788 ("The Path Forward for Identity
+> Federation"), proven on the `aws` package:
+>
+> 1. Bump the package **major version** on `main`, freeing the previous
+>    major's version namespace for a backport branch.
+> 2. Cut a long-running `backport-<package>-<N>.x` branch from the last
+>    release commit. It keeps the old `format_version` and Kibana floor and
+>    carries both patch **and** minor fixes for old-stack users.
+> 3. EPR version routing does the rest: old stacks resolve the backport
+>    line, new stacks resolve `main`.
+> 4. Split the PRs: the major/spec bump lands separately from the
+>    federation (`var_groups`) change.
+>
+> This needs sign-off from every team in the package's CODEOWNERS before any
+> constraint changes.
+
 ### 0.2 Identify agentless-eligible inputs
 
 Only these input types can run agentless and therefore support federation:
@@ -77,7 +97,14 @@ Only these input types can run agentless and therefore support federation:
 For each policy template, list every input and mark it eligible (E) or
 ineligible (I). You will use this list in §2, §3, and §4.
 
-If **no** inputs are eligible, federation cannot be added — stop and report.
+If **no** inputs are eligible, federation cannot be added — stop. The report
+must be actionable, not just negative: name each blocking input type and the
+upstream dependency that would unblock it. Example, for an `aws-s3`-only
+package:
+
+> `<package>` cannot be federated: its only input is `aws-s3`, which does not
+> run agentless. Blocked until the `aws-s3` input supports agentless
+> deployments; no package-level change can work around that.
 
 ### 0.3 Audit the credential vars
 

--- a/skills/federate-aws-integration/SKILL.md
+++ b/skills/federate-aws-integration/SKILL.md
@@ -131,6 +131,31 @@ options to emit). If federation-required vars are missing, copy their
 definitions from the `aws` package (same names, types, `show_user: false`,
 `required: false` — the var_group controls requirement).
 
+**If the audit finds NO AWS credential vars at all** (no access keys, no
+`role_arn`, no `auth.aws` block in any stream template), do not proceed
+silently and do not hard-abort. First verify whether the underlying input
+actually supports AWS authentication:
+
+1. Check the input's beats module / agent implementation: does it consume
+   `auth.aws` (or equivalent AWS credential config) at all? An input that
+   reads a local endpoint (e.g. `awsfargate/metrics` reading the ECS task
+   metadata endpoint from inside the task) makes no AWS API calls — added
+   credential vars would be dead configuration.
+2. **If the input supports AWS auth** but the package never exposed the
+   vars: **ask the user** whether to add the minimum required credential
+   var set for agentless + Federated Identity:
+   - `role_arn`, `external_id`, `supports_identity_federation`
+     (the `identity_federation` option)
+   - `access_key_id`, `secret_access_key` (the `direct_access_key` option —
+     the only other option visible in agentless mode)
+
+   On yes: add these per §1.1, emit only those two var_group options in
+   §1.2, and add the full `auth.aws` block to the stream templates per §4.
+3. **If the input does not support AWS auth**: stop with an actionable
+   report naming the input and why scaffolding vars would be dead config —
+   and flag the package for removal from the rollout scope if an issue
+   lists it.
+
 > **Unverified assumption:** the package-spec validator accepts input-level
 > var references, but Fleet UI rendering of var_groups against input-level
 > vars has not been end-to-end verified. If the UI misbehaves, fall back to

--- a/skills/federate-aws-integration/SKILL.md
+++ b/skills/federate-aws-integration/SKILL.md
@@ -5,9 +5,10 @@ description: >
   integration package in elastic/integrations. Use when asked to "add federation
   to <package>", "enable Identity Federation on <package>", or to repeat the
   pattern proven on the `aws` package for another AWS integration. Template
-  generation is handled by the IaC Provider (IaCP) — no static CFT URL is used.
-  Produces manifest edits, provider_permissions declarations, agent-template
-  patches, a changelog entry, and a validation checklist.
+  generation is IaC Provider (IaCP)-first, with the incremental static
+  federated-identity CFT wired as the fallback via iac_template_url.
+  Produces manifest edits, provider_permissions declarations, a CFT update,
+  agent-template patches, a changelog entry, and a validation checklist.
 license: Apache-2.0
 metadata:
   author: elastic
@@ -24,16 +25,21 @@ Use this skill when tasks include:
 - Repeating the var_groups / auth.aws / provider_permissions pattern proven on the `aws` package
 - Determining whether a package's inputs are eligible for federation
 
-Template generation is IaC Provider (IaCP)-driven. The `cloud-iac-provisioner`
+Template generation is IaC Provider (IaCP)-first: the `cloud-iac-provisioner`
 service renders IAM role templates dynamically at onboard time from the
-package's declared `provider_permissions`. Do **not** add a static
-CloudFormation quick-create URL (`iac_template_url`) for packages added via
-this skill — that belongs to the older static-CFT flow.
+package's declared `provider_permissions`. The static
+`federated-identity-aws.yml` CFT (elastic/cloudbeat) is the **fallback** —
+Kibana opens it via the option's `iac_template_url` when the IaCP render
+fails (422/502). Both are fed from the same `provider_permissions`
+declarations: §3 declares them, §3.1 mirrors them into the CFT, §1.2 wires
+the fallback URL.
 
 > **Warning when reading the `aws` package as a reference:** its
 > `identity_federation` var_groups option carries an `iac_template_url`
-> pointing at a static GuardDuty CFT. That is the legacy flow — do not copy
-> that key into new packages.
+> pointing at the legacy GuardDuty-only CFT
+> (`cloudformation-cloud-connectors-guardduty-*.yml`). Do not copy that URL —
+> new packages point at the incremental `federated-identity-aws` template
+> (§1.2).
 
 ## Background
 
@@ -234,6 +240,7 @@ var_groups:
         vars: [role_arn, external_id, supports_identity_federation]
         hide_in_deployment_modes: [default]
         provider: aws
+        iac_template_url: https://console.aws.amazon.com/cloudformation/home#/stacks/quickcreate?templateURL=https://elastic-cspm-cft.s3.eu-central-1.amazonaws.com/cloudformation-federated-identity-aws-9.4.0.yml&param_ElasticResourceId=RESOURCE_ID
       - name: direct_access_key
         title: Direct Access Keys
         vars: [access_key_id, secret_access_key]
@@ -275,8 +282,18 @@ Rules enforced by the package-spec validator:
 - Vars referenced by a var_group **must not have `required: true`** —
   requirement is controlled by the var_group itself.
 
-Note: `iac_template_url` is intentionally omitted from `identity_federation`.
-Template generation is handled by the IaC Provider at onboard time.
+**`iac_template_url` is the fallback path.** Kibana renders via the IaC
+Provider first; when the render fails (422/502) it falls back to opening this
+quick-create URL. It uses the same S3 bucket and URL shape as the merged
+`aws` package's URL, but with the incremental `federated-identity-aws`
+template (published by cloudbeat's `publish_cft.sh` as
+`cloudformation-federated-identity-aws-<version>.yml`). Pin the version
+segment to the package's Kibana floor minor (e.g. `9.4.0`), matching the
+`aws` package convention. Keep `RESOURCE_ID` literal — Kibana substitutes it.
+
+> The fallback only works once the template is published to S3
+> (cloudbeat#7422 must merge and release first). Until then the URL 404s on
+> fallback — the integrations PR should note that dependency.
 
 ### 1.3 Bump `format_version` and conditions
 
@@ -403,6 +420,50 @@ Optional `roles` attach managed policies alongside inline permissions:
 To determine the correct IAM actions, check the input's actual API calls
 (agent stream template, CEL program, or beats module docs) — do not guess.
 Prefer the minimal read-only set.
+
+### 3.1 Mirror the permissions into the static CFT (bridge until IaCP ships)
+
+Until the IaC Provider render path is live end-to-end, the deployable
+template is the static `deploy/cloudformation/federated-identity-aws.yml` in
+elastic/cloudbeat. It grows **incrementally**: one block per federated
+integration, containing exactly the permissions that integration declared in
+§3 — never grant ahead of a declaration.
+
+For each `provider_permissions` entry with `provider: aws`:
+
+- **`permissions`** → add one inline policy resource named after the package
+  (CamelCase with an `Elastic` prefix, e.g. `ElasticAwsSecurityHub`),
+  attached to `ElasticFederatedIdentityRole`:
+
+```yaml
+  ElasticAwsSecurityHub:
+    Type: AWS::IAM::Policy
+    Properties:
+      PolicyName: ElasticAwsSecurityHub
+      Roles:
+        - !Ref ElasticFederatedIdentityRole
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          # <package>: <description from provider_permissions>
+          - Sid: ElasticAwsSecurityHubRead
+            Effect: Allow
+            Action:
+              - securityhub:GetFindings
+            Resource: '*'
+```
+
+- **`roles`** (managed policies) → append each `id` ARN to the role's
+  `ManagedPolicyArns`, with a comment naming the declaring package.
+
+Validate with `cfn-lint` (or `pre-commit run cfn-python-lint --files
+deploy/cloudformation/federated-identity-aws.yml`).
+
+> **Current state:** the template lives on the unmerged cloudbeat PR branch
+> (`seanrathier/federated-identity-aws-cft`, cloudbeat#7422 — being reworked
+> from an all-at-once grant to this incremental model). Until it merges and
+> publishes to S3, apply this step in the local cloudbeat checkout only; the
+> integrations PR must not depend on the unpublished template.
 
 ---
 


### PR DESCRIPTION
## Summary

Adds `skills/federate-aws-integration`: a skill that enables Federated Identity (Cloud Connectors) on an agentless-eligible AWS integration package in elastic/integrations, capturing the pattern proven on the `aws` package (elastic/integrations#19828) as a repeatable procedure an agent can apply to any target package.

Closes elastic/ingest-dev#8804.

## What the skill covers

- **Pre-flight checks** — `format_version >= 3.6.4` (required by `provider_permissions`), Kibana/Agent `^9.4.0` floors (required by `auth.aws`), the agentless input-eligibility check (only `cel`, `httpjson`, `*metrics`, and `aws-cloudwatch` qualify), and a credential-var audit that classifies existing vars as federation-required / agentless-compatible / agent-only / auxiliary
- **Escalations instead of silent decisions** — if the Kibana floor bump would drop a supported stack line (e.g. `^8.16.5 || ^9.0.0` → `^9.4.0` abandons 8.x), the skill stops and proposes the branching strategy from elastic/ingest-dev#8788 (major bump on `main` + long-running `backport-<pkg>-N.x` branch); if a `format_version` jump surfaces pre-existing validator violations, it prescribes a separate mechanical pre-landing PR (elastic/integrations#19824 precedent)
- **No-credential-surface triage** — when a package declares no AWS auth vars at all, the skill verifies against the input's beats module whether it consumes `auth.aws`: if yes, it asks the user whether to scaffold the minimum var set; if no (e.g. `awsfargate/metrics`, which reads the local ECS task metadata endpoint), it stops with an actionable report and flags the package for scope removal
- **Manifest edits** — the `supports_identity_federation` var, a `var_groups` credential selector built from the audit (agent-only credential methods keep working via `hide_in_deployment_modes: [agentless]`), and an agentless `deployment_modes` refactor including input-level `deployment_modes: ["default"]` pinning for ineligible inputs
- **`provider_permissions` declarations** (package-spec 3.6.4) at the narrowest applicable level — the single source of truth feeding both template paths below
- **Two template paths from one declaration** — primary: the IaC Provider renders the IAM role template at onboard time from `provider_permissions`; fallback: the static `federated-identity-aws.yml` CFT in elastic/cloudbeat, which grows incrementally (one inline policy per federated integration, `roles` → `ManagedPolicyArns`; never granting ahead of a declaration) and is wired via the option's `iac_template_url` so Kibana can open it when the IaCP render fails (422/502)
- **Agent stream template patch** — the `auth.aws` / `use_cloud_connectors` hook in `*.yml.hbs`
- **Kibana policy-group membership** as a conditional step: `CLOUD_CONNECTOR_PERMISSION_ALLOWLIST` controls connector *sharing*, not rendering — a package absent from it still renders standalone, so most packages need no Kibana change
- **Validation and PR checklists**, including `cfn-lint` on the CFT and the serverless end-to-end onboard check

## Tested against real packages

The skill was exercised on three packages covering the happy path and both abort paths:

- **`aws_securityhub` (happy path)** — produced elastic/integrations#20435 (pipeline hygiene pre-landing, 514 violations surfaced by the format_version bump) and elastic/integrations#20436 (the federation change, stacked). The §3 "don't guess IAM actions" rule caught a real trap: the CEL program calls the `GetFindingsV2` API, but per the AWS API reference it authorizes as `securityhub:GetFindings`, not `securityhub:GetFindingsV2`.
- **`cisco_umbrella` (abort: ineligible inputs)** — `aws-s3`-only package; the skill stops and names the unblocking dependency (`aws-s3` agentless support).
- **`awsfargate` (abort: no credential surface)** — the beats module's config is a single `period` field and the metricset hard-requires the ECS-injected local metadata endpoint; the skill proved federation is structurally impossible and the package was flagged for removal from the elastic/ingest-dev#8812 scope.

## Verification notes

Claims in the skill were verified against primary sources rather than derived from prior notes:

- `var_groups`, `provider_permissions`, input-level `deployment_modes`, and the agentless `deployment_modes` fields were checked against the package-spec schema, semantic validators (`validate_var_groups.go`), and the spec's `good_var_groups` / `good_provider_permissions` test packages
- `provider_permissions` introduction in spec 3.6.4 confirmed from the package-spec changelog
- Allowlist semantics confirmed from the Fleet plugin source (`CLOUD_CONNECTOR_PERMISSION_ALLOWLIST` and its consumer hook)
- The `securityhub:GetFindings` authorization for `GetFindingsV2` confirmed from the AWS Security Hub API reference
- One knowingly unverified assumption is marked as such in the skill: Fleet UI rendering of `var_groups` that reference input-level vars has not been end-to-end verified (the spec validator accepts them); the skill documents a fallback

Also registers the skill in `.claude-plugin/marketplace.json` and the README domain-skills table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
