### PR TITLE
docs(mito-reference): document events divergence and Windows portability

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ The following tools must be installed and available on `$PATH` for the agent wor
 
 All Go tools require a working [Go](https://go.dev/dl/) installation with `$GOPATH/bin` on your `$PATH`.
 
-> **Windows:** All Go tools install and run on Windows. The Docker image `docker.elastic.co/observability/stream` is an alternative to `go install` for the mock server if you prefer not to use Go. Bash examples using process substitution or Unix paths require manual adaptation.
+> **Windows:** All Go tools install and run on Windows. Bash examples using process substitution or Unix paths require manual adaptation.
 
 ### npx (Recommended)
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ The following tools must be installed and available on `$PATH` for the agent wor
 
 All Go tools require a working [Go](https://go.dev/dl/) installation with `$GOPATH/bin` on your `$PATH`.
 
-> **Windows:** `go install github.com/elastic/stream@latest` does not compile on Windows (`unix.SignalNum` is undefined). Use the Docker image `docker.elastic.co/observability/stream` for the mock server instead. The other Go tools (`elastic-package`, `mito`, `celfmt`, `ceplx`, `kbdash`) install and run normally on Windows.
+> **Windows:** All Go tools install and run on Windows. The Docker image `docker.elastic.co/observability/stream` is an alternative to `go install` for the mock server if you prefer not to use Go. Bash examples using process substitution or Unix paths require manual adaptation.
 
 ### npx (Recommended)
 

--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ The following tools must be installed and available on `$PATH` for the agent wor
 
 All Go tools require a working [Go](https://go.dev/dl/) installation with `$GOPATH/bin` on your `$PATH`.
 
+> **Windows:** `go install github.com/elastic/stream@latest` does not compile on Windows (`unix.SignalNum` is undefined). Use the Docker image `docker.elastic.co/observability/stream` for the mock server instead. The other Go tools (`elastic-package`, `mito`, `celfmt`, `ceplx`, `kbdash`) install and run normally on Windows.
+
 ### npx (Recommended)
 
 The fastest way to install skills is with the skills CLI. No need to clone this repository — just run:
@@ -141,6 +143,17 @@ npx skills update
 ```
 
 **Working with the integrations repository:** If you are developing integrations against [`elastic/integrations`](https://github.com/elastic/integrations), run these skills from a checkout of that repo or point your agent at that tree. This gives the agent the real package layout, shared conventions, and surrounding packages for context. Several `elastic-package` commands (system tests, workspace-aware workflows) also require an integrations-style workspace to run correctly.
+
+## Recommended workflow
+
+Run `/research-integration` first to investigate the vendor's API, data formats, and field schemas, then pass the research output directly into `/create-integration`:
+
+```
+/research-integration <vendor or product name>
+/create-integration @research_results/<product_slug>/research-brief.md
+```
+
+Skipping `/research-integration` or bringing a pre-existing collector (such as a Go program to adapt into a CEL program) deviates from the optimized path and may produce lower-quality output — the build skills are tuned to consume the structured research brief format.
 
 ## Skills reference
 

--- a/skills/cel-programs/references/mito-reference.md
+++ b/skills/cel-programs/references/mito-reference.md
@@ -14,11 +14,10 @@ mito -version
 stream version
 ```
 
-> **Windows:** `go install github.com/elastic/stream@latest` does not compile on
-> Windows (`unix.SignalNum` is undefined). Use the Docker image
-> `docker.elastic.co/observability/stream` instead. Examples in this reference
+> **Windows:** All tools install and run on Windows. Examples in this reference
 > that use bash process substitution (`<(echo ...)`) or Unix paths require manual
-> adaptation on Windows.
+> adaptation. The Docker image `docker.elastic.co/observability/stream` is an
+> alternative to `go install` for the mock server if you prefer not to use Go.
 
 ---
 

--- a/skills/cel-programs/references/mito-reference.md
+++ b/skills/cel-programs/references/mito-reference.md
@@ -16,8 +16,7 @@ stream version
 
 > **Windows:** All tools install and run on Windows. Examples in this reference
 > that use bash process substitution (`<(echo ...)`) or Unix paths require manual
-> adaptation. The Docker image `docker.elastic.co/observability/stream` is an
-> alternative to `go install` for the mock server if you prefer not to use Go.
+> adaptation.
 
 ---
 

--- a/skills/cel-programs/references/mito-reference.md
+++ b/skills/cel-programs/references/mito-reference.md
@@ -14,6 +14,12 @@ mito -version
 stream -version
 ```
 
+> **Windows:** `go install github.com/elastic/stream@latest` does not compile on
+> Windows (`unix.SignalNum` is undefined). Use the Docker image
+> `docker.elastic.co/observability/stream` instead. Examples in this reference
+> that use bash process substitution (`<(echo ...)`) or Unix paths require manual
+> adaptation on Windows.
+
 ---
 
 ## Core usage
@@ -83,6 +89,14 @@ The JSON file mirrors what the CEL input provides at runtime. Include `cursor` t
 5. `"cursor"` values in the output would be persisted across restarts in the real CEL input
 
 Control re-evaluation depth with `-max_executions`. Use `-1` to verify natural pagination termination (watch for infinite loops; interrupt with Ctrl+C).
+
+---
+
+## Known divergences from the real CEL input
+
+**`events` are not stripped between `want_more` cycles in mito — they are in the real input.**
+
+mito prints `events` from each evaluation and retains them in state for the next cycle. The real CEL input removes `events` before re-evaluating. Do not add `drop("events")` to work around this during mock testing; the beats runtime already handles the strip. Code that adds `drop("events")` looks correct against mito but is flagged as unnecessary in review.
 
 ---
 


### PR DESCRIPTION
Add a "Known divergences from the real CEL input" section after the Execution
model section: mito retains events in state between want_more cycles; the real
CEL input strips them. Prevents the drop("events") anti-pattern that looks
correct against the mock but is flagged in review.
