### PR TITLE
Fix the stream install command in the mito reference

### DIFF
--- a/skills/cel-programs/references/mito-reference.md
+++ b/skills/cel-programs/references/mito-reference.md
@@ -8,10 +8,10 @@ Companion to the `cel-programs` skill. Covers everything needed to use mito for 
 
 ```bash
 go install github.com/elastic/mito/cmd/mito@latest
-go install github.com/elastic/stream/cmd/stream@latest
+go install github.com/elastic/stream@latest
 # Both install to ~/go/bin/ — ensure that is in PATH
 mito -version
-stream -version
+stream version
 ```
 
 ---


### PR DESCRIPTION
## Proposed commit message

```
Fix the stream install command in the mito reference

`go install github.com/elastic/stream/cmd/stream@latest` fails because
that package does not exist. stream's main package sits at the module
root, so the correct path is `github.com/elastic/stream@latest`. This
was reported by a Windows user who could not install stream.

`stream -version` is wrong for the same block: version is a subcommand
rather than a flag, so the flag form fails with "unknown shorthand
flag: 'v' in -version".

The repository README already documented the correct install path, so
this brings the mito reference in line with it.
```

Relates: https://github.com/elastic/stream/pull/210 (fixes the windows build)