### PR TITLE
fix: make CEL tool prerequisite check portable and fix install paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,20 @@ The following tools must be installed and available on `$PATH` for the agent wor
 
 All Go tools require a working [Go](https://go.dev/dl/) installation with `$GOPATH/bin` on your `$PATH`.
 
+To install every Go tool at once (idempotent — skips what you already have):
+
+```bash
+for pkg in \
+  github.com/elastic/elastic-package \
+  github.com/elastic/celfmt/cmd/celfmt \
+  github.com/elastic/stream \
+  github.com/elastic/mito/cmd/mito \
+  github.com/efd6/ceplx/cmd/ceplx \
+  github.com/efd6/kbdash; do
+  command -v "${pkg##*/}" >/dev/null || go install "$pkg@latest"
+done
+```
+
 ### npx (Recommended)
 
 The fastest way to install skills is with the skills CLI. No need to clone this repository — just run:

--- a/skills/create-integration/references/add-datastream-workflow.md
+++ b/skills/create-integration/references/add-datastream-workflow.md
@@ -36,7 +36,11 @@ elastic-package --help
 If any CEL data streams are being added, also verify:
 
 ```bash
-for t in mito celfmt ceplx stream; do command -v "$t" >/dev/null || echo "MISSING: $t"; done
+m=
+for t in mito celfmt ceplx stream; do
+  command -v "$t" >/dev/null || { echo "MISSING: $t"; m=1; }
+done
+[ -n "$m" ] || echo "all CEL tools present"
 ```
 
 If anything is reported missing, install it now with the single install loop in `scaffold-commands.md` Preconditions. Do not skip this: missing tools produce silent degraded output rather than early failures.

--- a/skills/create-integration/references/add-datastream-workflow.md
+++ b/skills/create-integration/references/add-datastream-workflow.md
@@ -36,10 +36,10 @@ elastic-package --help
 If any CEL data streams are being added, also verify:
 
 ```bash
-mito -version && celfmt -version && ceplx -version && stream -version
+for t in mito celfmt ceplx stream; do command -v "$t" >/dev/null || echo "MISSING: $t"; done
 ```
 
-If CEL tools are missing, install them now — see `scaffold-commands.md` Preconditions for install commands. Do not skip this: missing tools produce silent degraded output rather than early failures.
+If anything is reported missing, install it now with the single install loop in `scaffold-commands.md` Preconditions. Do not skip this: missing tools produce silent degraded output rather than early failures.
 
 ## Phase 1: Parse context and verify package
 

--- a/skills/create-integration/references/create-workflow.md
+++ b/skills/create-integration/references/create-workflow.md
@@ -37,7 +37,11 @@ elastic-package --help
 If any CEL data streams are planned, also verify:
 
 ```bash
-for t in mito celfmt ceplx stream; do command -v "$t" >/dev/null || echo "MISSING: $t"; done
+m=
+for t in mito celfmt ceplx stream; do
+  command -v "$t" >/dev/null || { echo "MISSING: $t"; m=1; }
+done
+[ -n "$m" ] || echo "all CEL tools present"
 ```
 
 If anything is reported missing, install it now with the single install loop in `references/scaffold-commands.md` Preconditions. Do not skip this: missing tools produce silent degraded output (`celfmt` and `ceplx` steps are silently skipped rather than failing with a clear error) and the resulting PR will require extra review cycles.

--- a/skills/create-integration/references/create-workflow.md
+++ b/skills/create-integration/references/create-workflow.md
@@ -37,10 +37,10 @@ elastic-package --help
 If any CEL data streams are planned, also verify:
 
 ```bash
-mito -version && celfmt -version && ceplx -version && stream -version
+for t in mito celfmt ceplx stream; do command -v "$t" >/dev/null || echo "MISSING: $t"; done
 ```
 
-If CEL tools are missing, install them now — see `references/scaffold-commands.md` Preconditions for install commands. Do not skip this: missing tools produce silent degraded output (`celfmt` and `ceplx` steps are silently skipped rather than failing with a clear error) and the resulting PR will require extra review cycles.
+If anything is reported missing, install it now with the single install loop in `references/scaffold-commands.md` Preconditions. Do not skip this: missing tools produce silent degraded output (`celfmt` and `ceplx` steps are silently skipped rather than failing with a clear error) and the resulting PR will require extra review cycles.
 
 ## Phase 1: Parse context
 

--- a/skills/create-integration/references/scaffold-commands.md
+++ b/skills/create-integration/references/scaffold-commands.md
@@ -9,24 +9,23 @@ Before running scaffold commands, verify:
 2. you are in the correct directory (see working directory rules below)
 3. package/data stream name is finalized (renames later are noisy)
 
-**For integrations with CEL data streams, also verify these tools before starting:**
+**For integrations with CEL data streams, the CEL tools must be present before starting.** Run this one block — it is idempotent, installing only what is missing, so it serves as both the check and the install:
 
 ```bash
-mito -version      # github.com/elastic/mito/cmd/mito
-celfmt -version    # github.com/elastic/mito/cmd/celfmt
-ceplx -version     # github.com/efd6/ceplx/cmd/ceplx
-stream -version    # github.com/elastic/stream/cmd/stream
+for pkg in \
+  github.com/elastic/mito/cmd/mito \
+  github.com/elastic/celfmt/cmd/celfmt \
+  github.com/efd6/ceplx/cmd/ceplx \
+  github.com/elastic/stream; do
+  command -v "${pkg##*/}" >/dev/null || go install "$pkg@latest"
+done
 ```
 
-Missing CEL tools produce silent degraded output — `celfmt` and `ceplx` steps are skipped without warning, resulting in PRs that require extra review cycles to catch what the tooling should have caught automatically. Install any missing tools before proceeding:
+All four land in `$(go env GOPATH)/bin` (usually `~/go/bin`) — ensure that is on `PATH`.
 
-```bash
-go install github.com/elastic/mito/cmd/mito@latest
-go install github.com/elastic/mito/cmd/celfmt@latest
-go install github.com/efd6/ceplx/cmd/ceplx@latest
-go install github.com/elastic/stream/cmd/stream@latest
-# All install to ~/go/bin/ — ensure that is on PATH
-```
+Missing CEL tools produce silent degraded output — `celfmt` and `ceplx` steps are skipped without warning, resulting in PRs that require extra review cycles to catch what the tooling should have caught automatically.
+
+Always probe with `command -v`, never with `-version`: of these four only `mito` accepts a `-version` flag. `celfmt` and `ceplx` exit 2 with `flag provided but not defined: -version`, and `stream` uses a `version` subcommand, so a chained `-version` check fails even when every tool is installed.
 
 ## Working directory rules
 


### PR DESCRIPTION
This pull request was drafted by 🤖 Claude Code/Opus 5 under my supervision.

### The `-version` prerequisite gate fails even when all four tools are installed

The gate chains `-version` across all four CEL tools, but only `mito` supports that flag. Verified by building all four from source and probing each one:

| Tool | `-version` | Actual result |
|------|-----------|---------------|
| `mito` | ✅ | `v1.27.0`, exit 0 |
| `celfmt` | ❌ | `flag provided but not defined: -version` + usage, **exit 2** |
| `ceplx` | ❌ | `flag provided but not defined: -version` + usage, **exit 2** |
| `stream` | ❌ | `unknown shorthand flag: 'v'`, exit 1 — it's a cobra subcommand (`stream version` → exit 0) |

So on a machine where **every tool is correctly installed**, the gate still fails:

```console
$ PATH="$GOBIN:$PATH" sh -c 'mito -version && celfmt -version && ceplx -version && stream -version'
v1.27.0
flag provided but not defined: -version
Usage of celfmt:
  -agent
        format agent config (incompatible with extract)
...
$ echo $?
2
```

It dies at `celfmt` and never reaches `ceplx` or `stream` — the workflow reports the CEL tools as unusable on every properly configured machine and sends the agent into a pointless reinstall.

### Two of the install commands don't resolve

Both fail with `no required module provides package`:

- `github.com/elastic/mito/cmd/celfmt@latest` — `elastic/mito` contains only `cmd/mito`; celfmt is its own repo → **`github.com/elastic/celfmt/cmd/celfmt`**
- `github.com/elastic/stream/cmd/stream@latest` — `elastic/stream` has `main.go` at the repo root, no `cmd/` dir → **`github.com/elastic/stream`**

The root `README.md` table already had both paths right, which is what the duplication costs us: four copies of the install instructions, two of them drifted.

### Fix: probe with `command -v`, install with one idempotent loop

Presence check — reports *every* missing tool instead of stopping at the first, and doesn't depend on per-tool flag conventions:

```bash
for t in mito celfmt ceplx stream; do command -v "$t" >/dev/null || echo "MISSING: $t"; done
```

Install — one block that replaces the separate check and install blocks, since it skips what's already present:

```bash
for pkg in \
  github.com/elastic/mito/cmd/mito \
  github.com/elastic/celfmt/cmd/celfmt \
  github.com/efd6/ceplx/cmd/ceplx \
  github.com/elastic/stream; do
  command -v "${pkg##*/}" >/dev/null || go install "$pkg@latest"
done
```

`${pkg##*/}` yields the correct binary name for all four. These can't be collapsed into a single `go install` — `go help install` requires all version-suffixed arguments to be in the same module, and these span three.

Both loops are POSIX, not bash-only — `command -v`, `${pkg##*/}`, `for`, `||`, no arrays or `[[ ]]`. Identical output and exit 0 under `/bin/sh` (bash 3.2 POSIX mode), `bash` 3.2.57, `zsh` 5.9, `ksh` 93u+, and `dash`.

### Why not `.tool-versions` / `mise.toml`

Considered and rejected on evidence (keeping this out of the docs — it's review context, not something a reader needs). `celfmt` and `ceplx` publish no semver tags, so the Go proxy returns only pseudo-versions and mise's `go:` backend won't resolve `latest`:

```console
$ mise install go:github.com/elastic/mito/cmd/mito@latest
mise go:github.com/elastic/mito/cmd/mito@1.27.0 ✓ installed

$ mise install go:github.com/elastic/celfmt/cmd/celfmt@latest
mise ERROR Failed to install go:github.com/elastic/celfmt/cmd/celfmt@latest: no versions found matching date filter
```

Separately, skills are installed via `npx skills` / the plugin marketplace without cloning this repo, so a repo-root version file would never reach users anyway.

### Verification

- Built all four into a sandboxed `GOBIN` from the corrected paths — all resolve and build
- Probed `-version` / `--version` / `version` on each, plus `elastic-package` and `kbdash`
- Ran the old gate with all four on `PATH` → exit 2; ran the new check loop on the same environment → clean
- Ran both loops under sh, bash, zsh, ksh and dash → identical, exit 0

### Follow-up: explicit success message on the check loop

@haetamoudi pointed out that the check loop produced no output when all tools were present, which can be misread as a silent failure. Appending `&& echo "all CEL tools present"` to the `for` loop does not work — the loop always exits 0, so both `MISSING:` lines and the success message would print.

Updated both workflow copies to:

```bash
m=
for t in mito celfmt ceplx stream; do
  command -v "$t" >/dev/null || { echo "MISSING: $t"; m=1; }
done
[ -n "$m" ] || echo "all CEL tools present"
```

#### Tests (bash / sh / zsh)

| Case | Shells | Observed |
|------|--------|----------|
| All present (stand-ins `ls cat echo sh`) | bash, sh, zsh | `all CEL tools present`, exit 0 |
| Partial missing (`ls nosuch_a echo nosuch_b`) | bash, sh, zsh | `MISSING: nosuch_a` then `MISSING: nosuch_b` only — no success line, exit 0 |
| All missing (fake names) | bash | one `MISSING:` line per tool, no success line, exit 0 |
| Naive `done && echo success` regression | bash | prints `MISSING:` **and** success — confirms why the flag/`[ -n "$m" ]` form is required |


---

Targets `fix/tool-prerequisite-check` rather than `main`, so it can be merged into #20 before that PR lands. @haetamoudi — yours to merge or cherry-pick.

Rebased onto the updated #20 branch. #21 landed the identical `mito-reference.md` install-path fix in the meantime, so that file is dropped from this PR and only the scaffold/workflow docs and README remain.

