### PR TITLE
docs: reframe Track E checklist as market coverage

### DIFF
--- a/skills/research-integration/SKILL.md
+++ b/skills/research-integration/SKILL.md
@@ -79,7 +79,7 @@ If the collection method is unknown at invocation time, read all three checklist
 Also load:
 
 5. `ecs-field-mappings` skill -- for ECS field mapping guidance during the analysis phase
-6. `references/competitive-siem-coverage-checklist.md` -- read this yourself so you know what to pass through; when dispatching the Track E subagent, point it at this file **by path** (do NOT paste its contents into the task prompt). The Track E subagent will read it in its own fresh context.
+6. `references/market-coverage-checklist.md` -- read this yourself so you know what to pass through; when dispatching the Track E subagent, point it at this file **by path** (do NOT paste its contents into the task prompt). The Track E subagent will read it in its own fresh context.
 7. `references/research-subagent-guidance.md` -- the operating manual every research subagent needs. **Do NOT read this file yourself** unless you specifically need to debug a subagent's behaviour. Instead, point every research subagent at this file **by path** in its task prompt and instruct it to read the file end-to-end before doing any other work. Embedding the file verbatim doubles its context cost.
 
 Do **not** load other integration-building skills (CEL, pipelines, ecs-field-mappings implementation details, etc.). Those are for implementation, not research.
@@ -104,7 +104,7 @@ research_results/<product_slug>/
     api-spec-notes.md         # API endpoint details, request/response examples (if API)
     log-format-notes.md       # log format details, sample lines (if log-based)
     field-schema-analysis.md  # detailed field inventories written by subagents
-    competitive-siem-coverage.md  # detailed competitive SIEM analysis (always created)
+    market-coverage.md  # detailed market coverage analysis (always created)
     sample-events/            # representative sample data files
       <event_type>.json       # one file per event type or data format variant
       <event_type>.log
@@ -142,7 +142,7 @@ Launch multiple research subagents in parallel using the platform's generic / ge
 
 **Required structure for every research subagent task prompt:**
 
-1. **Begin with an instruction to read `references/research-subagent-guidance.md`** (relative to the `research-integration` skill) end-to-end before doing any other work. That file is the subagent's operating manual — methodology, `temp/` usage, Python analysis idiom, result delivery contract, quality standards, and anonymization conventions. **Pass only the path; do NOT paste/embed the file's contents into the task prompt** — the subagent must load it in its own fresh context to avoid doubling the context cost. Track E follows the same pattern for the competitive-SIEM checklist.
+1. **Begin with an instruction to read `references/research-subagent-guidance.md`** (relative to the `research-integration` skill) end-to-end before doing any other work. That file is the subagent's operating manual — methodology, `temp/` usage, Python analysis idiom, result delivery contract, quality standards, and anonymization conventions. **Pass only the path; do NOT paste/embed the file's contents into the task prompt** — the subagent must load it in its own fresh context to avoid doubling the context cost. Track E follows the same pattern for the market coverage checklist.
 2. **State the working directory explicitly** so the subagent knows where to write:
    ```
    Working directory: research_results/<product_slug>/
@@ -222,31 +222,31 @@ Instruct the subagent to investigate:
 
 Provide: product name, collection method, any documentation URLs.
 
-#### Research Track E: Competitive SIEM coverage (always launch)
+#### Research Track E: Market coverage (always launch)
 
 **Always launch this track** in parallel with the other tracks. It is not conditional on collection method.
 
 Instruct the subagent to check whether IBM QRadar, Splunk, and Sumo Logic have an existing integration or app for the product being researched, and to document what each covers and how it collects data.
 
-The subagent must follow `references/competitive-siem-coverage-checklist.md` end-to-end. Point the subagent at that file **by path** and instruct it to read the entire file before doing any other work. **Do NOT paste the checklist contents into the task prompt** — the subagent will load it in its own fresh context. (This is in addition to the read-`references/research-subagent-guidance.md`-by-path directive from Phase 2.)
+The subagent must follow `references/market-coverage-checklist.md` end-to-end. Point the subagent at that file **by path** and instruct it to read the entire file before doing any other work. **Do NOT paste the checklist contents into the task prompt** — the subagent will load it in its own fresh context. (This is in addition to the read-`references/research-subagent-guidance.md`-by-path directive from Phase 2.)
 
-Competitor catalog starting points to include in the prompt:
+Platform catalog starting points to include in the prompt:
 - IBM QRadar: `https://www.ibm.com/products/qradar-siem/integrations`
 - Splunk: `https://splunkbase.splunk.com/apps`
 - Sumo Logic: `https://www.sumologic.com/help/docs/integrations/`
 
-For each competitor, the subagent must determine:
+For each platform, the subagent must determine:
 - Whether a matching integration/app exists (exact, partial, or no match)
 - Integration/app name, publisher, direct catalog link, version, and last-updated date
 - Which data sources and event types it covers (be specific, not generic)
 - Collection method used (API pull, syslog push, agent/forwarder, cloud delivery, etc.)
 - Protocol and wire format details (CEF, LEEF, JSON, key-value, etc.) if documented
 - Support tier (vendor-maintained, platform-built, community/partner, or unsupported)
-- Notable gaps or differentiators compared to what Elastic could offer
+- Notable gaps in coverage across all platforms
 
-Output: write all findings to `references/competitive-siem-coverage.md` using the structure defined in the checklist (summary table → per-competitor H2 sections → comparison notes). Return a concise inline summary with which competitors have integrations, the dominant collection method found, and the path to the written file.
+Output: write all findings to `references/market-coverage.md` using the structure defined in the checklist (summary table → per-platform H2 sections → comparison notes). Return a concise inline summary with which platforms have integrations, the dominant collection method found, and the path to the written file.
 
-Provide: product name, vendor name, common aliases or abbreviations for the product, and the **path** to `references/competitive-siem-coverage-checklist.md` (so the subagent reads it itself — do not paste the checklist content into the prompt).
+Provide: product name, vendor name, common aliases or abbreviations for the product, and the **path** to `references/market-coverage-checklist.md` (so the subagent reads it itself — do not paste the checklist content into the prompt).
 
 ### Phase 3: Synthesize and supplement
 
@@ -259,7 +259,7 @@ After all subagents return:
 5. **Resolve conflicts** between subagent findings. When sources disagree, prefer official vendor documentation over third-party sources.
 6. **Collect sample data** -- extract or compile representative sample events from documentation, API response examples, or log format guides. Save each as a separate file in the `sample-events/` subdirectory.
 7. **Review temp/ artifacts** if needed. Subagents may have downloaded repos, SDKs, or schemas into `temp/`. You can inspect these directly if you need more detail than what the subagent summaries and reference files provide.
-8. **Read `references/competitive-siem-coverage.md`** (written by Track E). Extract the summary table and overall comparison notes — these are used directly in section 1.5 of the research brief.
+8. **Read `references/market-coverage.md`** (written by Track E). Extract the summary table and overall comparison notes — these are used directly in section 1.5 of the research brief.
 
 ### Phase 4: ECS mapping analysis
 
@@ -288,7 +288,7 @@ Compile the full research brief following the template in `references/research-o
 
 The brief must be self-contained -- a reader should be able to use it as the sole input to `/create-integration` and have everything they need.
 
-When populating **section 1.5 (Competitive SIEM Coverage)**, use the summary table extracted from `references/competitive-siem-coverage.md` in Phase 3 step 8. Include the one-line summary paragraph and the three-row competitor table inline, then add a reference pointer: `See references/competitive-siem-coverage.md for full per-vendor analysis.`
+When populating **section 1.5 (Market Coverage)**, use the summary table extracted from `references/market-coverage.md` in Phase 3 step 8. Include the one-line summary paragraph and the three-row platform table inline, then add a reference pointer: `See references/market-coverage.md for full per-platform analysis.`
 
 ### Phase 7: API test script (API/CEL collection only)
 

--- a/skills/research-integration/references/market-coverage-checklist.md
+++ b/skills/research-integration/references/market-coverage-checklist.md
@@ -1,22 +1,24 @@
-# Competitive SIEM Coverage Checklist
+# Market Coverage Checklist
 
 Use this checklist for **Research Track E** on every research run, regardless of the product's collection method. The goal is to determine whether IBM QRadar, Splunk, and Sumo Logic already have an integration or app for the product being researched, and to document what each covers and how it collects data.
 
-This analysis feeds section 1.5 of the research brief and the detailed `references/competitive-siem-coverage.md` file.
+This analysis feeds section 1.5 of the research brief and the detailed `references/market-coverage.md` file.
 
 ---
 
-## Competitor catalog search strategy
+## Platform catalog search strategy
 
-For each competitor below, search its official app/integration marketplace using the product name, vendor name, and common aliases. Use these as your primary starting points — do not rely on general web searches unless the catalog search is inconclusive.
+For each platform below, search its official app/integration marketplace using the product name, vendor name, and common aliases. Use these as your primary starting points — do not rely on general web searches unless the catalog search is inconclusive.
 
-| Competitor | Catalog URL | Notes |
-|-----------|-------------|-------|
+> **Note on automated access:** Before fetching any catalog URL automatically, check the site's `robots.txt` (e.g. `https://splunkbase.splunk.com/robots.txt`) and terms of service. Prefer reading a single catalog page over bulk or repeated fetching. If automated access is restricted, note that and rely on your grounded knowledge instead.
+
+| Platform | Catalog URL | Notes |
+|----------|-------------|-------|
 | IBM QRadar | `https://www.ibm.com/products/qradar-siem/integrations` | Also check IBM X-Force Exchange and DSM (Device Support Module) listings |
 | Splunk | `https://splunkbase.splunk.com/apps` | Filter by the product/vendor name; check "Technology Add-ons" (TAs) specifically |
 | Sumo Logic | `https://www.sumologic.com/help/docs/integrations/` | Also check the in-product App Catalog documentation |
 
-### Search terms to try per competitor
+### Search terms to try per platform
 
 - [ ] Exact product name (e.g., "Okta", "CrowdStrike Falcon")
 - [ ] Vendor name alone (e.g., "Palo Alto", "Fortinet")
@@ -26,9 +28,9 @@ For each competitor below, search its official app/integration marketplace using
 
 ---
 
-## Per-competitor investigation items
+## Per-platform investigation items
 
-For each competitor (IBM QRadar, Splunk, Sumo Logic), capture the following if an integration/app is found:
+For each platform (IBM QRadar, Splunk, Sumo Logic), capture the following if an integration/app is found:
 
 ### Integration identity
 
@@ -37,7 +39,7 @@ For each competitor (IBM QRadar, Splunk, Sumo Logic), capture the following if a
 - [ ] **Catalog page URL:** direct link to the listing
 - [ ] **Version:** latest version number (if shown)
 - [ ] **Last updated date:** indicates how actively maintained the integration is
-- [ ] **Compatibility notes:** which SIEM platform versions are supported
+- [ ] **Compatibility notes:** which platform versions are supported
 
 ### Data coverage
 
@@ -49,7 +51,7 @@ For each competitor (IBM QRadar, Splunk, Sumo Logic), capture the following if a
 
 ### Collection method
 
-- [ ] **Collection mechanism:** how does the competitor collect data from the product?
+- [ ] **Collection mechanism:** how does the platform collect data from the product?
   - API pull (REST, GraphQL, vendor SDK)
   - Syslog push (UDP/TCP, RFC 3164/5424, CEF, LEEF)
   - Agent/forwarder (Splunk Universal Forwarder, IBM WinCollect, etc.)
@@ -57,7 +59,7 @@ For each competitor (IBM QRadar, Splunk, Sumo Logic), capture the following if a
   - Cloud delivery (S3, Event Hub, Pub/Sub)
   - Vendor-native forwarding (product pushes directly to SIEM)
 - [ ] **Protocol / format details:** CEF, LEEF, JSON, key-value — note the wire format if documented
-- [ ] **Authentication method:** how the SIEM authenticates to the product (if API-based)
+- [ ] **Authentication method:** how the platform authenticates to the product (if API-based)
 - [ ] **Configuration requirements:** what the user must set up on both sides
 
 ### Quality signals
@@ -71,20 +73,19 @@ For each competitor (IBM QRadar, Splunk, Sumo Logic), capture the following if a
 
 ## Comparison layer
 
-After gathering per-competitor data, assess the overall competitive landscape:
+After gathering per-platform data, assess the overall landscape:
 
-- [ ] **Coverage breadth:** which competitor covers the most data sources / event types?
-- [ ] **Collection method alignment:** is the predominant collection method the same across competitors, or do they differ? Does this align with or differ from the recommended Elastic collection method?
+- [ ] **Coverage breadth:** which platform covers the most data sources / event types?
+- [ ] **Collection method alignment:** is the predominant collection method the same across platforms, or do they differ?
 - [ ] **Maintenance status:** are the integrations actively maintained or stale?
-- [ ] **Gaps Elastic could address:** data sources or event types none of the competitors cover, or cover poorly
-- [ ] **Differentiators:** areas where Elastic's approach (e.g., ECS normalization, Elastic Agent, Fleet management) could provide a better experience than the competitive offerings
+- [ ] **Gaps and opportunities:** data sources or event types none of the platforms cover, or cover poorly — areas where a new integration could add meaningful value
 
 ---
 
 ## Quality standards
 
 - Only record integrations you have confirmed exist in the catalog. Do not infer or assume based on the vendor's general reputation.
-- If no integration is found for a competitor, record that explicitly as "No integration found" — do not omit the competitor from the output.
+- If no integration is found for a platform, record that explicitly as "No integration found" — do not omit the platform from the output.
 - Mark any detail that could not be confirmed from the catalog listing or its linked documentation with `[UNVERIFIED]`.
 - Prefer official marketplace/catalog pages over blog posts, press releases, or third-party reviews.
 - If a catalog listing is ambiguous (e.g., covers multiple products under one app), note the ambiguity rather than claiming full coverage.
@@ -93,10 +94,10 @@ After gathering per-competitor data, assess the overall competitive landscape:
 
 ## Output
 
-Write findings to `references/competitive-siem-coverage.md` in the working directory. Structure the file as:
+Write findings to `references/market-coverage.md` in the working directory. Structure the file as:
 
-1. **Summary table** — one row per competitor (used verbatim in research brief section 1.5)
-2. **Per-competitor H2 sections** — full detail for each of IBM QRadar, Splunk, and Sumo Logic
-3. **Comparison notes** — gaps, differentiators, and overall landscape assessment
+1. **Summary table** — one row per platform (used verbatim in research brief section 1.5)
+2. **Per-platform H2 sections** — full detail for each of IBM QRadar, Splunk, and Sumo Logic
+3. **Comparison notes** — gaps, opportunities, and overall landscape assessment
 
-Return a concise summary inline with: which competitors have integrations, the dominant collection method found, and the path to the written file.
+Return a concise summary inline with: which platforms have integrations, the dominant collection method found, and the path to the written file.

--- a/skills/research-integration/references/research-output-template.md
+++ b/skills/research-integration/references/research-output-template.md
@@ -37,17 +37,17 @@ Every section below should be populated. If a section does not apply, include it
 
 <Does an Elastic integration already exist for this product (check `integrations/packages/` and `packages/`)? If yes, what does it cover and what gaps exist? If no, note that this is a new integration.>
 
-### 1.5 Competitive SIEM coverage
+### 1.5 Market coverage
 
-<1-2 sentence summary of the overall competitive landscape: which competitors have integrations for this product, and how comprehensive is their coverage.>
+<1-2 sentence summary of the overall market landscape: which platforms have integrations for this product, and how comprehensive is their coverage.>
 
-| Vendor | Integration name | Supported data sources | Collection method | Link |
-|--------|-----------------|----------------------|-------------------|------|
+| Platform | Integration name | Supported data sources | Collection method | Link |
+|----------|-----------------|----------------------|-------------------|------|
 | IBM QRadar | <name or "No integration found"> | <data sources covered, or N/A> | <API / syslog / agent / N/A> | <URL or N/A> |
 | Splunk | <name or "No integration found"> | <data sources covered, or N/A> | <API / syslog / agent / N/A> | <URL or N/A> |
 | Sumo Logic | <name or "No integration found"> | <data sources covered, or N/A> | <API / syslog / agent / N/A> | <URL or N/A> |
 
-See `references/competitive-siem-coverage.md` for full per-vendor analysis including support tier, version, gaps, and comparison notes.
+See `references/market-coverage.md` for full per-platform analysis including support tier, version, gaps, and comparison notes.
 
 ## 2. Data Collection Method
 


### PR DESCRIPTION
## Summary

- Rename Research Track E and its artifacts to "market coverage".
- Update skill and research-brief template paths and wording (`market-coverage-checklist.md`, `market-coverage.md`, section 1.5).
- Focus on platform coverage and shared gaps rather than differentiators.

## Changes

- **research-integration** — Track E wording, paths, and section 1.5 in `SKILL.md` and `research-output-template.md`
- **references** — replace the old Track E checklist with `market-coverage-checklist.md`