### PR TITLE
Add grok-differential-testing skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,7 @@ In addition to the top-level skills, you can invoke any domain skill directly wh
 | `/input-configurations` | Input templates for all supported input types: CEL, HTTPJSON, syslog, filestream, AWS S3, Azure Event Hub, GCP Pub/Sub, and more |
 | `/package-spec` | Manifest rules, changelog schema, format version features |
 | `/integration-testing` | Pipeline testing, system testing, test fixture authoring |
+| `/grok-differential-testing` | Differential review of grok pattern changes: old-vs-new regression matrix, alternation-branch coverage, backtracking checks |
 | `/elastic-package-cli` | `elastic-package` CLI usage and troubleshooting |
 | `/dashboard-guidelines` | Kibana dashboard authoring standards |
 | `/dashboard-review` | Kibana dashboard review procedures |

--- a/skills/grok-differential-testing/SKILL.md
+++ b/skills/grok-differential-testing/SKILL.md
@@ -1,0 +1,129 @@
+---
+name: grok-differential-testing
+description: "Use when reviewing or refactoring grok patterns in ingest pipelines — model the old and new patterns as regexes and diff their accept/reject behaviour across a message-shape matrix to catch silent parsing regressions, untested alternation branches, and catastrophic backtracking. Trigger phrases: 'did this grok change break anything', 'review this grok refactor', 'check the pattern change', 'grok regression'."
+license: Apache-2.0
+metadata:
+  author: elastic
+  version: "1.0"
+---
+
+# grok-differential-testing
+
+Verify a change to grok patterns by diffing the behaviour of the **old** and **new** patterns
+across a matrix of message shapes, instead of trusting the fixtures that happen to exist.
+
+## When to use
+
+Load this skill whenever tasks include:
+
+- reviewing a PR that edits `patterns:` or `pattern_definitions:` in an ingest pipeline
+- refactoring several near-duplicate grok patterns into one parameterized pattern
+- making a previously required token optional (or vice versa)
+- assessing a claim that a pattern change is backwards compatible or backtracking-safe
+
+## When not to use
+
+Do not use this skill as the primary guide for:
+
+- designing new pipelines or choosing processors (`ingest-pipelines`)
+- authoring pipeline test fixtures and expected outputs (`integration-testing` → `references/pipeline-testing.md`)
+- dissect, kv, or other non-grok parser changes (the differential idea transfers, the harness does not)
+
+## Why differential
+
+A grok edit has a free oracle: **the previous pattern is the spec, minus the intended changes.**
+Fixture tests only pin the shapes someone already thought of. The dangerous failure mode of a
+grok refactor is the message shape nobody wrote a fixture for — a form the old pattern
+accepted incidentally (a `%{DATA}` catch-all, a permissive separator) that the new, tidier
+pattern silently rejects. Diffing old-vs-new over a generated shape matrix finds exactly the
+cases where behaviour changed, and every disagreement is either an intended improvement
+(which needs a fixture) or a regression (which needs a fix).
+
+Grok non-matches are rarely silent: most integration pipelines route processor failures
+through a top-level `on_failure` that sets `event.kind: pipeline_error`, so a lost shape
+means dropped fields **and** an error-classified event. Check the pipeline's failure handling
+and state the blast radius precisely in your report.
+
+## Workflow
+
+1. **Extract both pattern sets.** Get the old patterns from the git base
+   (`git show <base>:<pipeline>.yml`) and the new ones from the working tree — including
+   `pattern_definitions`, which is where refactors hide behaviour. Note the processor's
+   `if:` condition so you test the right event type.
+
+2. **Copy the harness.** Copy `references/grok_diff.py` into a scratch directory. It expands
+   grok syntax (`%{NAME}`, `%{NAME:field}`, custom definitions) into plain Python regexes.
+   Add any grok primitives the patterns use that the built-in table lacks — take their
+   definitions from [elastic/go-grok](https://github.com/elastic/go-grok/tree/main/patterns)
+   or the legacy [logstash pattern bank](https://github.com/logstash-plugins/logstash-patterns-core/tree/main/patterns).
+
+3. **Build the shape matrix.** Combine, as concrete message strings:
+   - every existing fixture message for the affected event types
+     (`grep` the package's `_dev/test/pipeline/` inputs);
+   - vendor-documented forms (link the doc in the case name);
+   - **combinatorial toggles of every optional segment** — each one alone, all present,
+     all absent. Three optional segments means at least 4–5 cases beyond the bundled-together one;
+   - hostile variants: doubled/missing spaces, trailing `\r`, empty capture values
+     (`[KEY=]`, `customername ` with nothing after), prefixes of the *wrong* shape
+     (whatever a removed `%{DATA}` catch-all used to absorb — other event-type prefixes
+     seen in the same pipeline are good candidates);
+   - one long adversarial non-matching input for the timing check.
+
+   Name each case and mark which are covered by repo fixtures — the uncovered ones become
+   your fixture recommendations.
+
+4. **Run the differential** (`diff()` in the harness) and classify each disagreement:
+
+   | old | new | Meaning | Action |
+   |-----|-----|---------|--------|
+   | ✔ | ✘ | **Regression.** | Blocker unless explicitly intended and called out in the changelog. |
+   | ✘ | ✔ | Newly enabled form. | Fine — but each one must gain a fixture, or it will rot. |
+   | ✘ | ✘ | Pre-existing gap on a plausible form. | Note it; out of scope unless cheap. |
+   | ✔ | ✔ | Compare **captures**, not just accept/reject. | A field that moved or emptied is also a regression. |
+
+5. **Check alternation-branch coverage.** For every alternation in the new
+   `pattern_definitions`, confirm at least one repo fixture exercises **each branch**.
+   A branch that only the harness has ever matched will be broken silently by the next edit.
+   Also probe empty-capture edges: does `[KEY=]` produce an empty-string keyword, and is
+   that wanted, or should the class be `+` instead of `*`?
+
+6. **Time the adversarial input** (`time_growth()` in the harness) at increasing sizes.
+   Linear growth: fine. Superlinear: restructure the pattern — the standard fix is a
+   negated character class (`[^\]]*`) instead of `.*?`/`%{DATA}` inside a repeated group.
+   Elasticsearch's grok watchdog will interrupt runaway matches at runtime, but that is a
+   mitigation, not a license: interrupted matches on a hot log path are a CPU tax and
+   turn into per-event failures.
+
+7. **Report.** Present the old/new verdict table, the branch-coverage findings, the timing
+   result, and a concrete fixture list (message string + which gap it closes). If reviewing
+   a PR, anchor findings to the pattern lines. Finish by running the real thing:
+   `elastic-package test pipeline` is the final word, not the harness.
+
+## Engine caveats
+
+The harness uses Python `re` to approximate the Oniguruma/joni engine Elasticsearch embeds.
+This is sound for differential analysis — both engines are backtracking NFA engines and the
+constructs integration patterns use (alternation, optional groups, lazy/greedy quantifiers,
+character classes) behave identically. It is **not** exact engine parity:
+
+- possessive quantifiers (`*+`) and atomic groups `(?>...)` are not supported by Python `re` —
+  if a pattern uses them, verify that piece with `elastic-package test pipeline` only;
+- grok type suffixes (`%{NUMBER:field:float}`) affect output typing, not matching — the
+  harness ignores them;
+- Oniguruma named groups may contain dots (`(?<a.b.c>...)`); the harness rewrites them to
+  valid Python names and reports captures under the original field name;
+- timing numbers are indicative, not absolute — use the growth *curve*, not the wall-clock.
+
+For ReDoS depth beyond the timing check, pipe the harness's expanded regex
+(`expand()` output) into [regexploit](https://github.com/doyensec/regexploit), which
+statically finds ambiguous-quantifier constructs and synthesizes worst-case inputs.
+
+## References
+
+- `references/grok_diff.py` — the harness: grok→regex expansion, first-match-wins pattern
+  sets, differential runner with capture comparison, adversarial timing. Stdlib-only;
+  run it bare for a self-test demonstrating the output format.
+- `references/worked-example.md` — a real review that used this method
+  ([elastic/integrations#20710](https://github.com/elastic/integrations/pull/20710)):
+  a two-pattern-to-one grok refactor where the shape matrix surfaced an untested
+  regression on a deliberately permissive catch-all, plus three fixture gaps.

--- a/skills/grok-differential-testing/references/grok_diff.py
+++ b/skills/grok-differential-testing/references/grok_diff.py
@@ -1,0 +1,171 @@
+r"""grok_diff.py — differential tester for grok pattern changes in ingest pipelines.
+
+Expands grok syntax into plain Python regexes so an OLD and NEW pattern set can be
+diffed over a matrix of message shapes. Stdlib-only. Approximates the Oniguruma/joni
+engine Elasticsearch embeds — sound for differential accept/reject analysis and
+backtracking growth curves, NOT exact engine parity (see SKILL.md "Engine caveats").
+Final validation is always `elastic-package test pipeline`.
+
+Usage sketch (see __main__ for a runnable self-test):
+
+    OLD = PatternSet(["^Source %{IP:src} - Dest %{IP:dst}$", ...], defs={...})
+    NEW = PatternSet(["^%{PREFIX_OPT}Source %{IP:src} - Dest %{IP:dst}$"],
+                     defs={"PREFIX_OPT": r"(?:\[[^\]]*\]%{SPACE})?"})
+    diff(CASES, OLD, NEW)          # CASES = [(name, message_string), ...]
+    time_growth(NEW, make_input)   # make_input(n) -> adversarial non-matching string
+"""
+
+import re
+import time
+
+# Common grok primitives, approximated. Add what your patterns need; take definitions
+# from https://github.com/elastic/go-grok/tree/main/patterns (authoritative for ES 8.16+)
+# or the legacy logstash-patterns-core bank. Keep additions NON-capturing.
+BASE_PATTERNS = {
+    "SPACE": r"\s*",
+    "DATA": r".*?",
+    "GREEDYDATA": r".*",
+    "WORD": r"\b\w+\b",
+    "NOTSPACE": r"\S+",
+    "INT": r"(?:[+-]?(?:[0-9]+))",
+    "NUMBER": r"(?:[+-]?(?:[0-9]+(?:\.[0-9]+)?)|\.[0-9]+)",
+    "BASE10NUM": r"(?:[+-]?(?:[0-9]+(?:\.[0-9]+)?)|\.[0-9]+)",
+    "IP": r"(?:(?:[0-9]{1,3}\.){3}[0-9]{1,3}|[0-9a-fA-F:]{2,})",  # IPv4 loose | IPv6 loose
+    "IPV4": r"(?:[0-9]{1,3}\.){3}[0-9]{1,3}",
+    "HOSTNAME": r"\b(?:[0-9A-Za-z][0-9A-Za-z-]{0,62})(?:\.(?:[0-9A-Za-z][0-9A-Za-z-]{0,62}))*\.?\b",
+    "USER": r"[a-zA-Z0-9._-]+",
+    "USERNAME": r"[a-zA-Z0-9._-]+",
+    "UUID": r"[A-Fa-f0-9]{8}-(?:[A-Fa-f0-9]{4}-){3}[A-Fa-f0-9]{12}",
+    "TIMESTAMP_ISO8601": r"(?:\d{4})-(?:0[1-9]|1[0-2])-(?:[0-2][0-9]|3[01])[T ](?:2[0123]|[01]?[0-9]):?(?:[0-5][0-9])(?::?(?:[0-5][0-9]|60)(?:[:.,][0-9]+)?)?(?:Z|[+-](?:2[0123]|[01]?[0-9])(?::?[0-5][0-9]))?",
+}
+
+_GROK_REF = re.compile(r"%\{(\w+)(?::([^}:]*))?(?::[^}]*)?\}")  # %{NAME}, %{NAME:field}, %{NAME:field:type}
+_ONIG_NAMED = re.compile(r"\(\?<([^>]+)>")                       # (?<field.with.dots>...)
+
+
+class GrokError(KeyError):
+    pass
+
+
+def expand(pattern, defs=None, base=BASE_PATTERNS, _depth=0):
+    """Expand grok references into a plain regex string.
+
+    Field captures become Python named groups with sanitized names; a parallel
+    name map is attached by PatternSet so captures report under the grok field name.
+    """
+    if _depth > 20:
+        raise GrokError("recursion limit — circular pattern_definitions?")
+    defs = defs or {}
+
+    def rep(m):
+        name, field = m.group(1), m.group(2)
+        body = defs.get(name, base.get(name))
+        if body is None:
+            raise GrokError(f"unknown grok pattern %{{{name}}} — add it to defs or BASE_PATTERNS")
+        body = expand(body, defs, base, _depth + 1)
+        if field:
+            return f"(?P<{_sanitize(field)}>{body})"
+        return f"(?:{body})"
+
+    out = _GROK_REF.sub(rep, pattern)
+    # Oniguruma named groups may contain dots; rewrite to valid Python names.
+    out = _ONIG_NAMED.sub(lambda m: f"(?P<{_sanitize(m.group(1))}>", out)
+    return out
+
+
+_name_registry = {}
+
+
+def _sanitize(field):
+    """Map a grok field name to a unique, valid Python group name."""
+    base = re.sub(r"\W", "_", field)
+    name, n = base, 1
+    while name in _name_registry and _name_registry[name] != field:
+        n += 1
+        name = f"{base}_{n}"
+    _name_registry[name] = field
+    return name
+
+
+def captures(match):
+    """Named captures of a match, keyed by original grok field name, Nones dropped."""
+    return {
+        _name_registry.get(k, k): v
+        for k, v in match.groupdict().items()
+        if v is not None
+    }
+
+
+class PatternSet:
+    """A grok processor's pattern list: first match wins."""
+
+    def __init__(self, patterns, defs=None, label=""):
+        self.label = label
+        self.compiled = [re.compile(expand(p, defs)) for p in patterns]
+
+    def match(self, text):
+        for rx in self.compiled:
+            m = rx.match(text)
+            if m:
+                return m
+        return None
+
+
+def diff(cases, old, new, show_captures=True):
+    """Print an old-vs-new verdict table; return [(name, old_ok, new_ok, changed)]."""
+    rows, width = [], max(len(n) for n, _ in cases) + 2
+    print(f"{'case':<{width}} {'old':>4} {'new':>4}  notes")
+    for name, msg in cases:
+        om, nm = old.match(msg), new.match(msg)
+        note = ""
+        if om and not nm:
+            note = "REGRESSION: old matched, new does not"
+        elif nm and not om:
+            note = "newly enabled — needs a fixture"
+        elif om and nm and show_captures:
+            oc, nc = captures(om), captures(nm)
+            moved = {k for k in oc.keys() | nc.keys() if oc.get(k) != nc.get(k)}
+            if moved:
+                note = "CAPTURE CHANGE: " + ", ".join(
+                    f"{k}: {oc.get(k)!r}->{nc.get(k)!r}" for k in sorted(moved))
+            elif nc:
+                note = " ".join(f"{k}={v!r}" for k, v in sorted(nc.items()))
+        rows.append((name, bool(om), bool(nm), bool(note.startswith(("REGRESSION", "CAPTURE")))))
+        print(f"{name:<{width}} {'YES' if om else 'no':>4} {'YES' if nm else 'NO!':>4}  {note}")
+    return rows
+
+
+def time_growth(pattern_set, make_input, sizes=(10, 20, 40, 80)):
+    """Time matching of adversarial inputs of growing size. Judge the CURVE:
+    linear is fine; superlinear means restructure the pattern."""
+    print(f"{'n':>5} {'chars':>7} {'ms':>10}")
+    for n in sizes:
+        s = make_input(n)
+        t = time.perf_counter()
+        pattern_set.match(s)
+        dt = (time.perf_counter() - t) * 1000
+        print(f"{n:>5} {len(s):>7} {dt:>10.3f}")
+
+
+if __name__ == "__main__":
+    # Self-test: a refactor that collapses two patterns into one and, in doing so,
+    # silently drops a shape the old catch-all accepted. Mirrors the class of bug
+    # found in elastic/integrations#20710.
+    OLD = PatternSet([
+        "^Source %{IP:src} - SSLRelay %{IP:relay} - user %{WORD:user}$",
+        "^%{DATA} Source %{IP:src} - user %{WORD:user}$",
+    ], label="1.18.6")
+    NEW = PatternSet([
+        "^%{PREFIX_OPT}Source %{IP:src} - (?:SSLRelay %{IP:relay} - )?user %{WORD:user}$",
+    ], defs={"PREFIX_OPT": r"(?:\[[^\]]*\]\s*)*"}, label="PR")
+
+    CASES = [
+        ("no prefix + relay",          "Source 10.0.0.1 - SSLRelay 10.0.0.2 - user bob"),
+        ("bracket prefix, no relay",   "[TCP][CGP] Source 10.0.0.1 - user bob"),
+        ("prefix + relay (was gap)",   "[TCP] Source 10.0.0.1 - SSLRelay 10.0.0.2 - user bob"),
+        ("bare (was gap)",             "Source 10.0.0.1 - user bob"),
+        ("non-bracket prefix",         "Client_ip 10.9.9.9 - Source 10.0.0.1 - user bob"),
+    ]
+    diff(CASES, OLD, NEW)
+    print()
+    time_growth(NEW, lambda n: "[" + "][".join(["X" * 20] * n) + "] Source not-an-ip")

--- a/skills/grok-differential-testing/references/worked-example.md
+++ b/skills/grok-differential-testing/references/worked-example.md
@@ -1,0 +1,48 @@
+# Worked example: elastic/integrations#20710 (citrix_adc)
+
+A real review that used this method end-to-end:
+[the review](https://github.com/elastic/integrations/pull/20710#pullrequestreview-4960138153)
+on [elastic/integrations#20710](https://github.com/elastic/integrations/pull/20710).
+
+## The change under review
+
+The `citrix_adc` SSLVPN pipeline parsed `ICASTART` events with two near-duplicate grok
+patterns that had a coverage gap (bracket prefix **and** `SSLRelayAddress` together matched
+neither). The PR collapsed them into one pattern built from three optional
+`pattern_definitions` segments, and swapped a `%{DATA} ?` catch-all prefix in the sibling
+`ICAEND_CONNSTAT` patterns for the same bracket-only `ICA_PREFIX` definition:
+
+```
+ICA_PREFIX:    (?:(?:\[[^\]]*\]%{SPACE})*?\[ICAUUID=(?<...ica_uuid>[^\]]*)\]%{SPACE}|(?:\[[^\]]*\]%{SPACE})+)?
+CLIENT_IP_OPT: (?:Client_ip %{IP:...client_ip}%{SEP})?
+SSL_RELAY_OPT: (?:SSLRelayAddress %{IP:...}:%{INT:...}%{SEP})?
+```
+
+The PR's own fixtures covered 4 shapes; all passed. Everything looked green.
+
+## What the differential found
+
+Both old and new pattern sets were modelled as regexes and diffed over 17 message shapes
+(repo fixtures + vendor-documented forms + combinatorial toggles + hostile variants):
+
+| Finding | Method step that caught it |
+|---|---|
+| `%{DATA} ?` → `ICA_PREFIX` narrowing: `Client_ip …` and `Context …@… - SessionId: …` prefixes parsed in the old version, fail in the new one — all ~18 ICAEND fields dropped and `event.kind: pipeline_error` set | Hostile variants: feed the removed catch-all prefixes of the *wrong* shape, seen elsewhere in the same pipeline |
+| The UUID-less branch of the `ICA_PREFIX` alternation — the branch the changelog names — was exercised by **zero** repo fixtures | Alternation-branch coverage check |
+| The changelog claimed `client.geo`/`client.as` enrichment, but the only fixture used `Client_ip 0.0.0.0`, which no geo/ASN database resolves — the claim was never asserted | Capture comparison + reading the expected output, not just the verdict |
+| `Client_ip` alone (no prefix, no relay) — the form the change exists for — had no fixture | Combinatorial toggles of optional segments |
+| `[ICAUUID=]` captures an empty-string keyword because the class is `[^\]]*` not `[^\]]+` | Empty-capture edge probe |
+| The backtracking-safety comment was **verified true**: 80 bracket blocks (1801 chars) on a non-matching line, <0.01 ms, linear growth | Adversarial timing |
+
+The headline regression was invisible to the PR's test suite precisely because the old
+pattern's permissiveness was undocumented — no fixture had ever pinned it. The differential
+made the old behaviour the spec and surfaced the narrowing in minutes.
+
+## Takeaways
+
+- The `%{DATA}` you delete is load-bearing until proven otherwise. Find what it absorbed
+  by feeding prefixes from *other* event types in the same pipeline.
+- "All tests pass" measures the fixtures, not the change. Diff against the old pattern.
+- Verify performance claims in comments; do not just read them. This one was true —
+  saying so with numbers is as valuable as finding it false.
+- Every alternation branch needs a fixture, or the next refactor breaks it silently.


### PR DESCRIPTION
## Summary

New domain skill: **`grok-differential-testing`** — review grok pattern changes in ingest pipelines by diffing the **old** and **new** patterns' accept/reject behaviour across a generated message-shape matrix, instead of trusting whichever fixtures happen to exist.

The core idea: a grok edit has a free oracle — the previous pattern is the spec, minus the intended changes. Fixture tests only pin shapes someone already thought of; the dangerous failure mode of a refactor is the shape the old pattern accepted incidentally (a `%{DATA}` catch-all, a permissive separator) that the tidier new pattern silently rejects.

## What's included

- `skills/grok-differential-testing/SKILL.md` — the workflow: extract both pattern sets from git base/head, build a shape matrix (fixtures + vendor forms + combinatorial toggles of optional segments + hostile variants), classify disagreements (regression / newly-enabled-needs-fixture / capture change), check alternation-branch fixture coverage, time adversarial inputs for backtracking growth. Ends with `elastic-package test pipeline` as the final word.
- `references/grok_diff.py` — stdlib-only harness: grok→regex expansion (incl. `pattern_definitions` and Oniguruma dotted named groups), first-match-wins pattern sets, differential runner with capture comparison, growth-curve timing. Running it bare executes a self-test demonstrating the output format on a miniature version of the real bug class.
- `references/worked-example.md` — the review that motivated this: [elastic/integrations#20710](https://github.com/elastic/integrations/pull/20710#pullrequestreview-4960138153), where the method surfaced an untested parsing regression (a deliberately permissive `%{DATA} ?` catch-all narrowed to bracket-only), an alternation branch with zero fixture coverage, and a changelog enrichment claim never asserted by any fixture — all invisible to the PR's green test suite.
- README: one row in the domain-skills table.

## Testing

- `python3 skills/grok-differential-testing/references/grok_diff.py` runs clean (also under `-W error::SyntaxWarning`) and demonstrates a regression catch + linear timing curve.
- The method itself was validated for real on elastic/integrations#20710 before being written up (see worked example).

---
_This PR is written by :robot: Claude Code/Fable 5 under my supervision._