### PR TITLE
docs: an input package's shipped pipeline is wired by its pipeline var

### DIFF
--- a/skills/input-configurations/references/common-input-patterns.md
+++ b/skills/input-configurations/references/common-input-patterns.md
@@ -14,32 +14,25 @@ The `preserve_original_event` tag must be conditional so users can opt in or out
 {{/if}}
 ```
 
-### Input packages: a shipped ingest pipeline is not wired in
+### Input packages: the shipped pipeline is not attached automatically
 
-An input package may carry `elasticsearch/ingest_pipeline/`, but it does not
-behave the way it does in an integration package. Fleet installs the shipped
-pipeline under a name derived from the **package version** — `<version>-default`,
-with no dataset in it, because an input package has no fixed dataset at install
-time — and never references it. The pipeline Fleet attaches to the data stream
-(`<type>-<package>.<dataset>-<version>`) contains only the four `@custom` hook
-stages:
+Fleet does not attach an input package's `elasticsearch/ingest_pipeline/` to the
+data stream the way it does for an integration package. The pipeline is
+installed, but nothing points at it on its own — the wiring is the package's own
+`pipeline` variable, written out by the template:
 
-```text
-global@custom
-<type>@custom
-<type>-<package>.integration@custom
-<type>-<package>.<dataset>@custom
+```yaml
+{{#if pipeline}}
+pipeline: {{pipeline}}
+{{/if}}
 ```
 
-Verified on a 9.4.3 stack with `packages/unifiedlogs`, which ships a
-34-processor pipeline: it installs as `0.5.2-default`, the data stream gets
-`logs-unifiedlogs.generic-0.5.2` carrying only the `@custom` stages, and the
-package's own `pipeline` variable default (`logs-unifiedlogs.log-default`)
-returns 404. Package-authored ingest logic never runs unless the `pipeline`
-variable is pointed at the actual installed name.
+`packages/unifiedlogs` carries exactly this block, and its `pipeline` default
+does not resolve to the pipeline as installed, so its shipped ingest logic never
+runs. If a package ships a pipeline, check that the variable's default names the
+installed pipeline rather than a guessed `logs-<package>.<dataset>-default`.
 
-Treat an input package as having no usable ingest pipeline: everything an
-integration would do there has to be done by the template. In particular
+For inputs that deliver a raw log line in `message` (`tcp`, `udp`, `unix`),
 `preserve_original_event` only adds the tag — populating `event.original` is the
 template's job:
 
@@ -53,7 +46,9 @@ processors:
 {{/if}}
 ```
 
-`packages/tcp`, `packages/udp` and `packages/unix` all do this.
+This is specific to that shape. `winlog` gets the field from `include_xml: true`,
+the object-storage and API inputs carry structured payloads rather than a raw
+line, and an integration package normally sets it in the ingest pipeline.
 
 ### User-defined tags
 
@@ -131,6 +126,6 @@ Each variable must have a sensible default defined in the manifest `vars` sectio
 | Hardcoded bucket/queue/topic IDs | **MEDIUM** | Cloud resource identifiers must be user-configurable |
 | Missing `forwarded` / `publisher_pipeline.disable_host` coupling | **MEDIUM** | If default tags include `forwarded`, the `publisher_pipeline.disable_host` block must be present, and vice versa |
 | Processors passthrough not at top level | **LOW** | The `{{#if processors}}` block must not be nested inside another key |
-| `preserve_original_event` without a `copy_fields` processor | **MEDIUM** | In an input package nothing else writes `event.original`; the tag alone leaves the field empty |
 | Missing `preserve_original_event` conditional | **MEDIUM** | The tag should be conditional, not hardcoded |
+| `preserve_original_event` without `copy_fields` in a raw-line input package (`tcp`/`udp`/`unix` shape) | **MEDIUM** | Nothing else writes `event.original` for these. Does not apply to `winlog` (`include_xml`), to structured-payload inputs, or to integration packages that set the field in the ingest pipeline |
 | Hardcoded timeouts or intervals | **LOW** | Tuning parameters should be variables with defaults |

--- a/skills/input-configurations/references/common-input-patterns.md
+++ b/skills/input-configurations/references/common-input-patterns.md
@@ -14,6 +14,47 @@ The `preserve_original_event` tag must be conditional so users can opt in or out
 {{/if}}
 ```
 
+### Input packages: a shipped ingest pipeline is not wired in
+
+An input package may carry `elasticsearch/ingest_pipeline/`, but it does not
+behave the way it does in an integration package. Fleet installs the shipped
+pipeline under a name derived from the **package version** — `<version>-default`,
+with no dataset in it, because an input package has no fixed dataset at install
+time — and never references it. The pipeline Fleet attaches to the data stream
+(`<type>-<package>.<dataset>-<version>`) contains only the four `@custom` hook
+stages:
+
+```text
+global@custom
+<type>@custom
+<type>-<package>.integration@custom
+<type>-<package>.<dataset>@custom
+```
+
+Verified on a 9.4.3 stack with `packages/unifiedlogs`, which ships a
+34-processor pipeline: it installs as `0.5.2-default`, the data stream gets
+`logs-unifiedlogs.generic-0.5.2` carrying only the `@custom` stages, and the
+package's own `pipeline` variable default (`logs-unifiedlogs.log-default`)
+returns 404. Package-authored ingest logic never runs unless the `pipeline`
+variable is pointed at the actual installed name.
+
+Treat an input package as having no usable ingest pipeline: everything an
+integration would do there has to be done by the template. In particular
+`preserve_original_event` only adds the tag — populating `event.original` is the
+template's job:
+
+```yaml
+{{#if preserve_original_event}}
+processors:
+- copy_fields:
+    fields:
+      - from: message
+        to: event.original
+{{/if}}
+```
+
+`packages/tcp`, `packages/udp` and `packages/unix` all do this.
+
 ### User-defined tags
 
 User-defined tags from the manifest variable are iterated with an `{{#each}}` block:
@@ -90,5 +131,6 @@ Each variable must have a sensible default defined in the manifest `vars` sectio
 | Hardcoded bucket/queue/topic IDs | **MEDIUM** | Cloud resource identifiers must be user-configurable |
 | Missing `forwarded` / `publisher_pipeline.disable_host` coupling | **MEDIUM** | If default tags include `forwarded`, the `publisher_pipeline.disable_host` block must be present, and vice versa |
 | Processors passthrough not at top level | **LOW** | The `{{#if processors}}` block must not be nested inside another key |
+| `preserve_original_event` without a `copy_fields` processor | **MEDIUM** | In an input package nothing else writes `event.original`; the tag alone leaves the field empty |
 | Missing `preserve_original_event` conditional | **MEDIUM** | The tag should be conditional, not hardcoded |
 | Hardcoded timeouts or intervals | **LOW** | Tuning parameters should be variables with defaults |

--- a/skills/input-configurations/references/common-input-patterns.md
+++ b/skills/input-configurations/references/common-input-patterns.md
@@ -27,17 +27,32 @@ pipeline: {{pipeline}}
 {{/if}}
 ```
 
-`packages/unifiedlogs` carries exactly this block, and its `pipeline` default
-does not resolve to the pipeline as installed, so its shipped ingest logic never
-runs. If a package ships a pipeline, check that the variable's default names the
-installed pipeline rather than a guessed `logs-<package>.<dataset>-default`.
+Fleet installs a shipped pipeline under a name derived from the package
+**version** — `<version>-default`, with no package or dataset part — and points
+nothing at it. The pipeline attached to the data stream carries only the
+`@custom` hook stages. `packages/unifiedlogs` carries exactly the block above,
+but its `pipeline` default is `logs-unifiedlogs.log-default`, which does not
+exist, so its shipped ingest logic never runs.
+
+So the default must name the pipeline as Fleet installs it, not a guessed
+`logs-<package>.<dataset>-default` — and because the name carries the version, it
+has to be updated on every version bump.
 
 For inputs that deliver a raw log line in `message` (`tcp`, `udp`, `unix`),
 `preserve_original_event` only adds the tag — populating `event.original` is the
 template's job:
 
 ```yaml
+{{#if processors}}
+processors:
 {{#if preserve_original_event}}
+- copy_fields:
+    fields:
+      - from: message
+        to: event.original
+{{/if}}
+{{processors}}
+{{else if preserve_original_event}}
 processors:
 - copy_fields:
     fields:
@@ -46,9 +61,17 @@ processors:
 {{/if}}
 ```
 
-This is specific to that shape. `winlog` gets the field from `include_xml: true`,
-the object-storage and API inputs carry structured payloads rather than a raw
-line, and an integration package normally sets it in the ingest pipeline.
+Note the shape: `copy_fields` is the first entry of the one `processors:` list the
+template emits, and the user's `{{processors}}` passthrough comes last. This
+supersedes the plain block under **Custom processors passthrough** rather than
+sitting next to it — emitting `processors:` twice in one template is a silent
+conflict. `packages/tcp`, `packages/udp` and `packages/unix` all use this chain,
+with an extra `{{else if syslog}}` branch.
+
+The `copy_fields` rule is specific to that shape. `winlog` gets the field from
+`include_xml: true`, the object-storage and API inputs carry structured payloads
+rather than a raw line, and an integration package normally sets it in the
+ingest pipeline.
 
 ### User-defined tags
 


### PR DESCRIPTION
> **Revised twice.** An earlier version claimed an input package gets no ingest pipeline at all; later versions claimed it has *no usable* pipeline. Both were wrong. The wiring path exists — the package's own `pipeline` variable — and the defect is a default that names a pipeline Fleet never creates. The final text is built around that; review history is in the threads.

## Problem

An input package can ship `elasticsearch/ingest_pipeline/`, but Fleet does not attach it to the data stream the way it does for an integration package. The only way to run it is the package's `pipeline` variable, written out by the template (`{{#if pipeline}} pipeline: {{pipeline}} {{/if}}`) — and that only works if the variable's default names the pipeline **as Fleet installs it**. Nothing in the skills says what that name is.

Separately, for inputs that deliver a raw log line in `message` (`tcp`, `udp`, `unix`), `preserve_original_event` only adds the tag; `event.original` has to be copied by the template.

## What actually happens

Fleet installs a shipped pipeline under a name derived from the **package version** — `<version>-default`, with no package or dataset part — and references it from nothing. The pipeline Fleet attaches to the data stream contains only the four `@custom` hook stages.

## Verification

Two input packages built from `packages/unifiedlogs` under different names and versions, installed on a local 9.4.3 stack with a package policy each:

| package | version | shipped pipeline | data stream pipeline |
| --- | --- | --- | --- |
| plumba | 1.2.3 | `1.2.3-default` (34 processors, unreferenced) | `logs-plumba.unifiedlogs-1.2.3` — 4 `@custom` stages only |
| plumbb | 4.5.6 | `4.5.6-default` (34 processors, unreferenced) | `logs-plumbb.unifiedlogs-4.5.6` — same |

Fleet's own `installed_es` lists the same names. `packages/unifiedlogs` itself sets `pipeline: {{pipeline}}` but defaults it to `logs-unifiedlogs.log-default`, which does not exist — so its shipped ingest logic never runs as configured.

## Changes

`input-configurations/references/common-input-patterns.md`:

- a subsection under "Tags": the `pipeline` var is the wiring, the installed name is `<version>-default` and changes on every version bump, and for raw-line inputs the `copy_fields` example uses the single `{{#if processors}} / {{else if}}` chain that `tcp`/`udp`/`unix` use (one `processors:` key, `copy_fields` first, user `{{processors}}` last) — so it does not collide with the passthrough block in the same file
- one review-flag row, scoped to the raw-line shape; `winlog` (`include_xml`), structured-payload inputs and integration packages are excluded by name

Touches the same file as #34 in different sections; both merge orders are conflict-free against current `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TT5Mp3Vmbo4dWPJt1PvrTy
