### PR TITLE
docs: document dynamic_signal_types and its otelcol restriction

### DIFF
--- a/skills/package-spec/references/format-version-features.md
+++ b/skills/package-spec/references/format-version-features.md
@@ -34,6 +34,7 @@ These features require bumping beyond the current standard. Only use them if the
 | Multiple template paths | 3.6.0 | [#1089](https://github.com/elastic/package-spec/pull/1089) |
 | Package dependencies (`requires` field) | 3.6.0 | [#1071](https://github.com/elastic/package-spec/pull/1071) |
 | OTel input type | 3.6.0 | [#1091](https://github.com/elastic/package-spec/pull/1091) |
+| `dynamic_signal_types` (otelcol only) | 3.6.0 | [#1067](https://github.com/elastic/package-spec/pull/1067), [#1091](https://github.com/elastic/package-spec/pull/1091) |
 | Input type migration | 3.6.0 | [#1021](https://github.com/elastic/package-spec/pull/1021) |
 | `var_groups` (policy template and input levels) | 3.6.1 | [#1120](https://github.com/elastic/package-spec/pull/1120) |
 | Named inputs in policy templates | 3.6.1 | [#1135](https://github.com/elastic/package-spec/pull/1135) |
@@ -44,6 +45,28 @@ These features require bumping beyond the current standard. Only use them if the
 | Transform `num_failure_retries` | 3.6.1 | [#1124](https://github.com/elastic/package-spec/issues/1124) |
 | ML modules in content packages | 3.6.2 | [#1149](https://github.com/elastic/package-spec/pull/1149) |
 | `semantic_text` field type | 3.7.0 (unreleased) | [#807](https://github.com/elastic/package-spec/pull/807) |
+
+## `dynamic_signal_types` is otelcol-only
+
+A policy template with `dynamic_signal_types: true` and no `type:` accepts every
+signal type at once — the mechanism for "one policy template, several signal
+types". It is restricted to `input: otelcol` and no released spec version lifts
+that:
+
+- `dynamic_signal_types: true` on any other input fails with
+  `policy template "<name>": dynamic_signal_types is only allowed when input is
+  'otelcol', got '<input>'`
+- `type:` must **not** be set alongside it — `type field must not be set when
+  dynamic_signal_types is true`
+- below `format_version: 3.6.0` the field is not recognised at all
+  (`Additional property dynamic_signal_types is not allowed`)
+
+Bumping the format version does not help: the restriction is unchanged through
+`3.7.0-next`, and the five packages using it in elastic/integrations
+(`otlp_input_otel`, `kafka_input_otel`, `elasticapm_input_otel`,
+`mysql_input_otel`, `sql_server_input_otel`) are all `input: otelcol`. For a
+non-otelcol input needing several signal types, see the shapes in
+`create-integration/references/package-layout.md`.
 
 ## Breaking changes at 3.6.0
 

--- a/skills/package-spec/references/format-version-features.md
+++ b/skills/package-spec/references/format-version-features.md
@@ -48,25 +48,31 @@ These features require bumping beyond the current standard. Only use them if the
 
 ## `dynamic_signal_types` is otelcol-only
 
-A policy template with `dynamic_signal_types: true` and no `type:` accepts every
-signal type at once — the mechanism for "one policy template, several signal
-types". It is restricted to `input: otelcol` and no released spec version lifts
-that:
+`dynamic_signal_types: true` lets one policy template accept every signal type at
+once. It is restricted to the `otelcol` input in **every** package type, and no
+released spec version lifts that — the restriction is unchanged through
+`3.7.0-next`. Below `format_version: 3.6.0` the field is not recognised at all
+(`Additional property dynamic_signal_types is not allowed`).
 
-- `dynamic_signal_types: true` on any other input fails with
-  `policy template "<name>": dynamic_signal_types is only allowed when input is
-  'otelcol', got '<input>'`
-- `type:` must **not** be set alongside it — `type field must not be set when
-  dynamic_signal_types is true`
-- below `format_version: 3.6.0` the field is not recognised at all
-  (`Additional property dynamic_signal_types is not allowed`)
+Where it sits differs, and the sibling `type:` means different things:
 
-Bumping the format version does not help: the restriction is unchanged through
-`3.7.0-next`, and the five packages using it in elastic/integrations
-(`otlp_input_otel`, `kafka_input_otel`, `elasticapm_input_otel`,
-`mysql_input_otel`, `sql_server_input_otel`) are all `input: otelcol`. For a
-non-otelcol input needing several signal types, see the shapes in
-`create-integration/references/package-layout.md`.
+| Package type | Field | Sibling `type:` |
+|---|---|---|
+| input | `policy_templates[].dynamic_signal_types` | the signal type — must be **absent** |
+| integration | `policy_templates[].inputs[].dynamic_signal_types` | the input name — must be **`otelcol`** |
+| integration | `streams[].dynamic_signal_types` (data stream manifest) | the input name, via `streams[].input` |
+
+So the input-package rule "`type` must not be set" does not carry over: in an
+integration package the neighbouring `type` is the input name and has to be
+there. The validator words them differently too — `type field must not be set
+when dynamic_signal_types is true` for input packages, `input type "<type>":
+dynamic_signal_types is only allowed when input is 'otelcol'` for integration
+packages.
+
+All five packages using the field today (`otlp_input_otel`, `kafka_input_otel`,
+`elasticapm_input_otel`, `mysql_input_otel`, `sql_server_input_otel`) are input
+packages; no integration package uses it yet. For a non-otelcol input that needs
+several signal types, see `create-integration/references/package-layout.md`.
 
 ## Breaking changes at 3.6.0
 


### PR DESCRIPTION
> **Revised.** The first version stated input-package rules as universal — the same
> defect @haetamoudi flagged on #35. Most importantly it said `type:` must not be set
> alongside `dynamic_signal_types`, which is true only for input packages; in an
> integration package the sibling `type:` is the *input name* and must be present and
> equal to `otelcol`. Corrected in 460d9af, along with two omissions. Details under
> **Correction** below.

## Problem

`dynamic_signal_types` is the supported mechanism for "one policy template, several signal types" — a policy template that accepts every signal type at once. The term appears in **no** skill file, so anyone reaching for that capability finds out about the restriction by hitting the validation error.

## Verification

Reproduced with `elastic-package v0.125.1` against a package built from `packages/tcp`:

| `format_version` | `dynamic_signal_types: true` on `input: tcp` |
| --- | --- |
| `3.6.0` | `policy template "tcp": dynamic_signal_types is only allowed when input is 'otelcol', got 'tcp'` |
| `3.5.0`, `3.4.0` | `Additional property dynamic_signal_types is not allowed` + `field policy_templates.0: type is required` |

Introduced in spec **3.6.0** ([#1067](https://github.com/elastic/package-spec/pull/1067), extended to integration packages by [#1091](https://github.com/elastic/package-spec/pull/1091)). No later changelog entry relaxes the otelcol restriction; the newest spec version is `3.7.0-next`.

In elastic/integrations exactly five packages use it — `otlp_input_otel`, `kafka_input_otel`, `elasticapm_input_otel`, `mysql_input_otel`, `sql_server_input_otel` — and all five are input packages with `input: otelcol`. No integration package uses it yet.

Bumping the format version is both necessary and insufficient: below 3.6.0 the field does not exist at all, but no bump lifts the otelcol restriction.

## Correction

The `packages/tcp` probe above is an **input** package, and the first version of this PR generalised from it. `validate_input_dynamic_signal_types.go` validates the two package types in separate functions, and they do not agree:

| Package type | Field | Sibling `type:` |
| --- | --- | --- |
| input | `policy_templates[].dynamic_signal_types` | the signal type — rejected when set (`type field must not be set when dynamic_signal_types is true`) |
| integration | `policy_templates[].inputs[].dynamic_signal_types` | the input name — must be `otelcol` (`input type "<type>": dynamic_signal_types is only allowed when input is 'otelcol'`) |
| integration | `streams[].dynamic_signal_types` (data stream manifest) | the input name, via `streams[].input` |

So the original text inverted the requirement for integration packages. It also omitted the data stream location entirely (`spec/integration/data_stream/manifest.spec.yml:700`) and quoted only the input-package wording of the otelcol error.

What survived verification unchanged: **3.6.0** for all three locations, the otelcol restriction applying to every package type (`spec.go:245`, and the validator's own `invalid_integration_package_non_otelcol_with_dynamic_signal_types` test case), and the five-package survey.

## Scope

`package-spec/references/format-version-features.md` — one row in the "Recent additions (3.5.0+)" table and one section.

The closing cross-reference now names `create-integration/references/package-layout.md` as a file rather than the section #33 adds, so this PR no longer depends on that one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TT5Mp3Vmbo4dWPJt1PvrTy
