### PR TITLE
docs: rewriting `input:` is not enough, the `.hbs` is named after the input

### DIFF
--- a/skills/create-integration/references/scaffold-commands.md
+++ b/skills/create-integration/references/scaffold-commands.md
@@ -96,6 +96,10 @@ Choose `--inputs` based on how the product sends data:
 
 Allowed input values: `aws-cloudwatch`, `aws-s3`, `azure-blob-storage`, `azure-eventhub`, `cel`, `entity-analytics`, `etw`, `filestream`, `gcp-pubsub`, `gcs`, `http_endpoint`, `journald`, `netflow`, `redis`, `tcp`, `udp`, `winlog`
 
+This list is the scaffolder's, not the spec's, and it is narrower than what the agent supports — `mqtt`, for one, is rejected here but advertised by a 9.4.3 agent. For an input outside the list, scaffold with an allowed one and rewrite afterwards. Rewriting `input:` in the data stream manifest is **not enough**: the generated template is named after the input (`agent/stream/<input>.yml.hbs`) and its contents are input-specific, so rename the file and replace its body.
+
+Nothing catches a half-done rewrite. package-spec does not validate input names, so a manifest naming one input while the only template is still the other passes `elastic-package lint` *and* `check`, and `check` goes on to build the zip.
+
 ### What `create data-stream` generates
 
 - `data_stream/<name>/manifest.yml` — data stream config with input streams and vars


### PR DESCRIPTION
## Problem

`scaffold-commands.md` lists the `--inputs` allowlist without saying whose list it is. It is the scaffolder's, not the spec's, and it is narrower than what the agent supports:

```
$ elastic-package create data-stream --name probe --type logs --inputs mqtt
Error: invalid input type "mqtt"; allowed values: [aws-cloudwatch aws-s3
azure-blob-storage azure-eventhub cel entity-analytics etw filestream
gcp-pubsub gcs http_endpoint journald netflow redis tcp udp winlog]
```

`mqtt` is rejected here but advertised by a 9.4.3 agent in its "Detected available inputs and outputs" line. The obvious workaround is to scaffold with an allowed input and rewrite afterwards — and that has a trap the file does not mention.

## The trap

`create data-stream` generates `agent/stream/<input>.yml.hbs` — named after the input, with input-specific contents. The file already documents that, three lines below. Rewriting `input:` in the data stream manifest therefore leaves the wrong template in place, and **nothing catches it**.

Verified with `elastic-package v0.125.1` on an integration package, `input: tcp` changed to `input: mqtt` while `tcp.yml.hbs` was the only template present:

| command | result |
| --- | --- |
| `elastic-package lint` | `Done` |
| `elastic-package check` | `Done` — built `nginx-3.2.2.zip` |

The mismatch is invisible to the whole toolchain, because package-spec does not validate input names.

## Changes

Two paragraphs under the existing `Allowed input values:` line: whose list it is, and that the rewrite has to rename the template file and replace its body, with the reason nothing warns you.

## Note on scope

This started as a second bullet in #35 (`package-spec`). @haetamoudi pointed out that it duplicated this file's allowlist verbatim and that `package-spec/SKILL.md` lists package scaffolding under "When NOT to use" — so the fact belongs here instead. Split out as its own PR; it stands on its own and does not depend on #35.

## Verification

`mqtt` rejection, the `<input>.yml.hbs` naming, and the green `lint`/`check` on a mismatched package were each reproduced with `elastic-package v0.125.1` against a `format_version: "3.0.2"` integration package. Not run: loading the modified skill into a live agent session — this is a reference-file edit with no workflow or frontmatter change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TT5Mp3Vmbo4dWPJt1PvrTy